### PR TITLE
feat: add Fable.Beam.Cowboy bindings and target .NET 10 only

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           dotnet-version: 10.x
 
+      - name: Setup Erlang/OTP
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          rebar3-version: '3'
+
       - name: Install just
         uses: extractions/setup-just@v3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,5 @@ jobs:
         run: just pack-version ${TAG_NAME#v}
 
       - name: Push NuGet
-        run: dotnet nuget push src/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push 'src/**/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
         continue-on-error: false

--- a/Fable.Beam.sln
+++ b/Fable.Beam.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
@@ -7,22 +7,64 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Beam", "src\Fable.Bea
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Beam.Test", "test\Fable.Beam.Test.fsproj", "{B2C3D4E5-2345-6789-ABCD-EF0123456789}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cowboy", "cowboy", "{F724575D-0906-23D3-55E0-0F90BC21CE96}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Beam.Cowboy", "src\cowboy\Fable.Beam.Cowboy.fsproj", "{AAD39E24-066B-47CA-B8F5-662812DBE779}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1234-5678-9ABC-DEF012345678}.Release|x86.Build.0 = Release|Any CPU
 		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Debug|x86.Build.0 = Debug|Any CPU
 		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|x64.Build.0 = Release|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-2345-6789-ABCD-EF0123456789}.Release|x86.Build.0 = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|x64.Build.0 = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Debug|x86.Build.0 = Debug|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|x64.ActiveCfg = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|x64.Build.0 = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|x86.ActiveCfg = Release|Any CPU
+		{AAD39E24-066B-47CA-B8F5-662812DBE779}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F724575D-0906-23D3-55E0-0F90BC21CE96} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{AAD39E24-066B-47CA-B8F5-662812DBE779} = {F724575D-0906-23D3-55E0-0F90BC21CE96}
 	EndGlobalSection
 EndGlobal

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,43 @@
+# Releasing
+
+This project uses [EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt)
+for release automation and [Conventional Commits](https://www.conventionalcommits.org/)
+for versioning.
+
+## Commit conventions
+
+PR titles must follow the conventional commit format (enforced by CI):
+
+| Prefix | Version bump | Example |
+| --- | --- | --- |
+| `feat:` | minor | `feat: add Phoenix bindings` |
+| `fix:` | patch | `fix: correct cowboy_req reply signature` |
+| `feat!:` | major | `feat!: rename Erlang module` |
+| `chore:` | patch | `chore: update dependencies` |
+| `docs:` | patch | `docs: update README` |
+| `refactor:` | patch | `refactor: simplify ETS bindings` |
+
+Other valid prefixes: `test`, `perf`, `ci`, `build`, `style`, `revert`.
+
+## Creating a release
+
+```bash
+just shipit
+```
+
+This will:
+
+1. Analyze commits since the last release
+2. Determine the next semantic version
+3. Update `CHANGELOG.md`
+4. Create a GitHub release with the version tag (e.g. `v0.1.0`)
+
+The GitHub release triggers the publish workflow, which:
+
+1. Packs all NuGet packages (`Fable.Beam`, `Fable.Beam.Cowboy`, etc.)
+2. Pushes them to nuget.org using the `NUGET_API_KEY` secret
+
+## Prerequisites
+
+- `NUGET_API_KEY` repository secret (glob pattern: `Fable.Beam*`)
+- `GITHUB_TOKEN` or `gh` CLI authenticated (for ShipIt to create releases)

--- a/justfile
+++ b/justfile
@@ -54,14 +54,16 @@ test-dotnet:
     dotnet build {{test_path}}
     dotnet run --project {{test_path}}
 
-# Create NuGet package
+# Create NuGet packages
 pack:
     dotnet build {{src_path}}
     dotnet pack {{src_path}} -c Release
+    dotnet pack {{src_path}}/cowboy -c Release
 
-# Create NuGet package with specific version (used in CI)
+# Create NuGet packages with specific version (used in CI)
 pack-version version:
     dotnet pack {{src_path}} -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
+    dotnet pack {{src_path}}/cowboy -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
 
 # Format code with Fantomas
 format:

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,7 @@
 
 source https://api.nuget.org/v3/index.json
 storage: none
-framework: netstandard2.0, netstandard2.1, net6.0, net8.0, net9.0, net10.0
+framework: net10.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core 5.0.0-rc.1

--- a/paket.lock
+++ b/paket.lock
@@ -1,5 +1,5 @@
 STORAGE: NONE
-RESTRICTION: || (== net10.0) (== net6.0) (== net8.0) (== net9.0) (== netstandard2.0) (== netstandard2.1)
+RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Fable.Core (5.0.0-rc.1)

--- a/src/Fable.Beam.fsproj
+++ b/src/Fable.Beam.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Author>Dag Brattli</Author>
     <Copyright>Dag Brattli</Copyright>

--- a/src/cowboy/Cowboy.fs
+++ b/src/cowboy/Cowboy.fs
@@ -1,0 +1,17 @@
+/// Fable bindings for the Cowboy HTTP server.
+/// See: https://ninenines.eu/docs/en/cowboy/2.12/manual/cowboy/
+module Fable.Beam.Cowboy.Cowboy
+
+open Fable.Core
+
+/// Start a clear (HTTP) listener.
+[<Emit("cowboy:start_clear($0, $1, $2)")>]
+let startClear (name: obj) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+
+/// Start a TLS (HTTPS) listener.
+[<Emit("cowboy:start_tls($0, $1, $2)")>]
+let startTls (name: obj) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+
+/// Stop a running listener.
+[<Emit("cowboy:stop_listener($0)")>]
+let stopListener (name: obj) : obj = nativeOnly

--- a/src/cowboy/CowboyReq.fs
+++ b/src/cowboy/CowboyReq.fs
@@ -1,0 +1,72 @@
+/// Fable bindings for Cowboy's cowboy_req module.
+/// See: https://ninenines.eu/docs/en/cowboy/2.12/manual/cowboy_req/
+module Fable.Beam.Cowboy.CowboyReq
+
+open Fable.Core
+
+/// Opaque Cowboy request object.
+type Req = obj
+
+/// Get the HTTP method (e.g. <<"GET">>, <<"POST">>).
+[<Emit("cowboy_req:method($0)")>]
+let method' (req: Req) : string = nativeOnly
+
+/// Get the request path (e.g. <<"/api/users">>).
+[<Emit("cowboy_req:path($0)")>]
+let path (req: Req) : string = nativeOnly
+
+/// Get a specific header value.
+[<Emit("cowboy_req:header($0, $1)")>]
+let header (name: string) (req: Req) : string = nativeOnly
+
+/// Get a specific header value with a default.
+[<Emit("cowboy_req:header($0, $1, $2)")>]
+let headerDefault (name: string) (req: Req) (defaultValue: string) : string = nativeOnly
+
+/// Get all request headers as a map.
+[<Emit("cowboy_req:headers($0)")>]
+let headers (req: Req) : obj = nativeOnly
+
+/// Read the full request body. Returns {ok, Body, Req}.
+[<Emit("cowboy_req:read_body($0)")>]
+let readBody (req: Req) : obj * byte array * Req = nativeOnly
+
+/// Get the query string.
+[<Emit("cowboy_req:qs($0)")>]
+let queryString (req: Req) : string = nativeOnly
+
+/// Send a full response: status, headers map, body, req.
+[<Emit("cowboy_req:reply($0, $1, $2, $3)")>]
+let reply (status: int) (headers: obj) (body: string) (req: Req) : Req = nativeOnly
+
+/// Send a response with status and headers only (no body).
+[<Emit("cowboy_req:reply($0, $1, $2)")>]
+let replyNoBody (status: int) (headers: obj) (req: Req) : Req = nativeOnly
+
+/// Get the peer IP address and port.
+[<Emit("cowboy_req:peer($0)")>]
+let peer (req: Req) : obj * int = nativeOnly
+
+/// Get the scheme (<<"http">> or <<"https">>).
+[<Emit("cowboy_req:scheme($0)")>]
+let scheme (req: Req) : string = nativeOnly
+
+/// Get the host.
+[<Emit("cowboy_req:host($0)")>]
+let host (req: Req) : string = nativeOnly
+
+/// Get the port number.
+[<Emit("cowboy_req:port($0)")>]
+let port (req: Req) : int = nativeOnly
+
+/// Parse query string into a list of key-value pairs.
+[<Emit("cowboy_req:parse_qs($0)")>]
+let parseQs (req: Req) : obj = nativeOnly
+
+/// Get a binding value from the route.
+[<Emit("cowboy_req:binding($0, $1)")>]
+let binding (name: obj) (req: Req) : obj = nativeOnly
+
+/// Get a binding value with a default.
+[<Emit("cowboy_req:binding($0, $1, $2)")>]
+let bindingDefault (name: obj) (req: Req) (defaultValue: obj) : obj = nativeOnly

--- a/src/cowboy/CowboyRouter.fs
+++ b/src/cowboy/CowboyRouter.fs
@@ -1,0 +1,9 @@
+/// Fable bindings for Cowboy's cowboy_router module.
+/// See: https://ninenines.eu/docs/en/cowboy/2.12/manual/cowboy_router/
+module Fable.Beam.Cowboy.CowboyRouter
+
+open Fable.Core
+
+/// Compile routing rules into a dispatch list.
+[<Emit("cowboy_router:compile($0)")>]
+let compile (routes: obj) : obj = nativeOnly

--- a/src/cowboy/Fable.Beam.Cowboy.fsproj
+++ b/src/cowboy/Fable.Beam.Cowboy.fsproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Author>Dag Brattli</Author>
+    <Copyright>Dag Brattli</Copyright>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+    <PackageTags>fsharp;fable;fable-binding;fable-beam;erlang;cowboy;http</PackageTags>
+    <Description>Fable bindings for Cowboy HTTP server on BEAM</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Cowboy.fs" />
+    <Compile Include="CowboyReq.fs" />
+    <Compile Include="CowboyRouter.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/src/cowboy/paket.references
+++ b/src/cowboy/paket.references
@@ -1,0 +1,2 @@
+FSharp.Core
+Fable.Core

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -7,6 +7,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <LangVersion>preview</LangVersion>
     <OutputType>Exe</OutputType>
+    <NoWarn>NU1510</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Fable.Beam.fsproj" />


### PR DESCRIPTION
## Summary
- Add `Fable.Beam.Cowboy` package with bindings for `cowboy`, `cowboy_req`, and `cowboy_router`
- Simplify all binding projects to target only `net10.0`
- Update pack/publish pipeline for mono-repo multi-package support (NuGet glob `src/**/Release/*.nupkg`)
- Add `RELEASING.md` documenting the ShipIt release workflow

## Test plan
- [x] Solution builds with 0 warnings and 0 errors
- [ ] CI passes build and test
- [ ] Verify `just pack` produces both `.nupkg` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)