### PR TITLE
feat: configure ShipIt for rc pre-release versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 5.0.0-rc.2
+
+### Features
+
+- Initial release placeholder

--- a/justfile
+++ b/justfile
@@ -90,5 +90,5 @@ watch:
     {{fable}} watch {{src_path}} --lang Erlang --outDir {{build_path}}
 
 # Run EasyBuild.ShipIt for release management
-shipit:
-    dotnet shipit
+shipit *args:
+    dotnet shipit --pre-release rc {{args}}


### PR DESCRIPTION
## Summary
- Seed `CHANGELOG.md` at `5.0.0-rc.2` so next ShipIt release produces `5.0.0-rc.3`, matching the Fable compiler version
- Update justfile `shipit` recipe to use `--pre-release rc` by default

## Test plan
- [ ] CI passes
- [ ] `just shipit` produces version `5.0.0-rc.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)