### PR TITLE
feat: add application module, Cowboy handler and WebSocket bindings

### DIFF
--- a/src/Fable.Beam.fsproj
+++ b/src/Fable.Beam.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="otp/Ets.fs" />
     <Compile Include="otp/Maps.fs" />
     <Compile Include="otp/Lists.fs" />
+    <Compile Include="otp/Application.fs" />
     <Compile Include="otp/File.fs" />
     <Compile Include="otp/Testing.fs" />
   </ItemGroup>

--- a/src/cowboy/CowboyHandler.fs
+++ b/src/cowboy/CowboyHandler.fs
@@ -1,0 +1,9 @@
+/// Fable helpers for Cowboy HTTP handler return types.
+/// See: https://ninenines.eu/docs/en/cowboy/2.12/manual/cowboy_handler/
+module Fable.Beam.Cowboy.CowboyHandler
+
+open Fable.Core
+
+/// Return {ok, Req, State} from init/2.
+[<Emit("{ok, $0, $1}")>]
+let ok (req: obj) (state: obj) : obj = nativeOnly

--- a/src/cowboy/CowboyWebsocket.fs
+++ b/src/cowboy/CowboyWebsocket.fs
@@ -1,0 +1,53 @@
+/// Fable helpers for Cowboy WebSocket handlers.
+/// See: https://ninenines.eu/docs/en/cowboy/2.12/manual/cowboy_websocket/
+module Fable.Beam.Cowboy.CowboyWebsocket
+
+open Fable.Core
+
+// -- Handler return types --
+
+/// Return {cowboy_websocket, Req, State} from init/2 to upgrade to WebSocket.
+[<Emit("{cowboy_websocket, $0, $1}")>]
+let upgrade (req: obj) (state: obj) : obj = nativeOnly
+
+/// Return {cowboy_websocket, Req, State, Opts} from init/2 with options.
+[<Emit("{cowboy_websocket, $0, $1, $2}")>]
+let upgradeWithOpts (req: obj) (state: obj) (opts: obj) : obj = nativeOnly
+
+/// Return {ok, State} from websocket_init/1 or websocket_handle/2.
+[<Emit("{ok, $0}")>]
+let ok (state: obj) : obj = nativeOnly
+
+/// Return {reply, Frame, State} to send a single frame.
+[<Emit("{reply, $0, $1}")>]
+let reply (frame: obj) (state: obj) : obj = nativeOnly
+
+/// Return {reply, Frames, State} to send multiple frames.
+[<Emit("{reply, $0, $1}")>]
+let replyMany (frames: obj list) (state: obj) : obj = nativeOnly
+
+/// Return {stop, State} to close the WebSocket connection.
+[<Emit("{stop, $0}")>]
+let stop (state: obj) : obj = nativeOnly
+
+// -- Frame constructors --
+
+/// Create a text frame: {text, Data}.
+[<Emit("{text, $0}")>]
+let textFrame (data: string) : obj = nativeOnly
+
+/// Create a binary frame: {binary, Data}.
+[<Emit("{binary, $0}")>]
+let binaryFrame (data: obj) : obj = nativeOnly
+
+/// Create a ping frame.
+[<Emit("ping")>]
+let pingFrame: obj = nativeOnly
+
+/// Create a pong frame.
+[<Emit("pong")>]
+let pongFrame: obj = nativeOnly
+
+/// Create a close frame: {close, Code, Reason}.
+[<Emit("{close, $0, $1}")>]
+let closeFrame (code: int) (reason: string) : obj = nativeOnly

--- a/src/cowboy/Fable.Beam.Cowboy.fsproj
+++ b/src/cowboy/Fable.Beam.Cowboy.fsproj
@@ -12,8 +12,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Cowboy.fs" />
+    <Compile Include="CowboyHandler.fs" />
     <Compile Include="CowboyReq.fs" />
     <Compile Include="CowboyRouter.fs" />
+    <Compile Include="CowboyWebsocket.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />

--- a/src/otp/Application.fs
+++ b/src/otp/Application.fs
@@ -1,0 +1,28 @@
+/// Type bindings for OTP application module
+/// See https://www.erlang.org/doc/apps/kernel/application
+module Fable.Beam.Application
+
+open Fable.Core
+
+// fsharplint:disable MemberNames
+
+[<Erase>]
+type IExports =
+    /// Starts an application and all its dependencies.
+    abstract ensure_all_started: app: obj -> obj
+    /// Starts an application.
+    abstract start: app: obj -> obj
+    /// Stops an application.
+    abstract stop: app: obj -> obj
+    /// Gets an application environment variable.
+    abstract get_env: app: obj * key: obj -> obj
+    /// Gets an application environment variable with default.
+    abstract get_env: app: obj * key: obj * defaultValue: obj -> obj
+    /// Sets an application environment variable.
+    abstract set_env: app: obj * key: obj * value: obj -> obj
+    /// Returns a list of all running applications.
+    abstract which_applications: unit -> obj
+
+/// application module
+[<ImportAll("application")>]
+let application: IExports = nativeOnly


### PR DESCRIPTION
## Summary
- Add `Application.fs` — OTP application module bindings: `ensure_all_started`, `start`, `stop`, `get_env`, `set_env`, `which_applications` (closes #4)
- Add `CowboyWebsocket.fs` — WebSocket handler helpers: `upgrade`, `ok`, `reply`, `stop`, frame constructors (`textFrame`, `binaryFrame`, `closeFrame`) (closes #5)
- Add `CowboyHandler.fs` — HTTP handler return type: `{ok, Req, State}` (closes #6)

## Test plan
- [x] Solution builds with 0 warnings and 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)