### PR TITLE
chore: release 5.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 ---
-last_commit_released: 59bc7d3f7254df74063d400b28d782853df722d8
+last_commit_released: ece4354234833a2a14951721fe5fc778512a5dea
 ---
 
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 5.0.0-rc.4 - 2026-03-11
+
+### 🚀 Features
+
+* Auto-release on ShipIt PR merge ([875273e](https://github.com/fable-compiler/Fable.Beam/commit/875273e24e310e26c4ab0067376de1a2720848cd))
+* Add application module, Cowboy handler and WebSocket bindings (#7) ([ece4354](https://github.com/fable-compiler/Fable.Beam/commit/ece4354234833a2a14951721fe5fc778512a5dea))
+
+### 🐞 Bug Fixes
+
+* Don't fail publish if GitHub release already exists ([74f22bd](https://github.com/fable-compiler/Fable.Beam/commit/74f22bdeed84c23e3948d6355a81bb0b6cea0149))
+
+<strong><small>[View changes on Github](https://github.com/fable-compiler/Fable.Beam/compare/59bc7d3f7254df74063d400b28d782853df722d8..ece4354234833a2a14951721fe5fc778512a5dea)</small></strong>
 
 ## 5.0.0-rc.3 - 2026-03-11
 


### PR DESCRIPTION
## 🤖 New versions available

| Project | Status | New Version |
| --- | :---: | :---: |
| Unnamed | 🚀 | 5.0.0-rc.4 |

**Legend:**
- ✅ No version bump required
- 🚀 New version
> [!TIP]
> 🤖 I was not able to find a meaningful name for all the projects
>
> You can help me by setting [`name`](https://github.com/easybuild-org/EasyBuild.ShipIt#name) in your `CHANGELOG.md` configuration

## Unnamed

### 5.0.0-rc.4 - 2026-03-11

#### 🚀 Features

* Auto-release on ShipIt PR merge ([875273e](https://github.com/fable-compiler/Fable.Beam/commit/875273e24e310e26c4ab0067376de1a2720848cd))
* Add application module, Cowboy handler and WebSocket bindings (#7) ([ece4354](https://github.com/fable-compiler/Fable.Beam/commit/ece4354234833a2a14951721fe5fc778512a5dea))

#### 🐞 Bug Fixes

* Don't fail publish if GitHub release already exists ([74f22bd](https://github.com/fable-compiler/Fable.Beam/commit/74f22bdeed84c23e3948d6355a81bb0b6cea0149))

<strong><small>[View changes on Github](https://github.com/fable-compiler/Fable.Beam/compare/59bc7d3f7254df74063d400b28d782853df722d8..ece4354234833a2a14951721fe5fc778512a5dea)</small></strong>


---
This PR was created automatically by [EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt)