### PR TITLE
fix: target netstandard2.0 instead of net10.0

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,7 @@
 
 source https://api.nuget.org/v3/index.json
 storage: none
-framework: net10.0
+framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core 5.0.0-rc.1
@@ -10,7 +10,7 @@ nuget Fable.Core 5.0.0-rc.1
 group Test
     source https://api.nuget.org/v3/index.json
     storage: none
-    framework: net10.0
+    framework: netstandard2.0
 
     nuget FSharp.Core
     nuget Fable.Core 5.0.0-rc.1

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,7 +10,7 @@ nuget Fable.Core 5.0.0-rc.1
 group Test
     source https://api.nuget.org/v3/index.json
     storage: none
-    framework: netstandard2.0
+    framework: net10.0
 
     nuget FSharp.Core
     nuget Fable.Core 5.0.0-rc.1

--- a/paket.lock
+++ b/paket.lock
@@ -8,13 +8,23 @@ NUGET
 
 GROUP Test
 STORAGE: NONE
-RESTRICTION: == netstandard2.0
+RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
+    Microsoft.CodeCoverage (18.3)
     Microsoft.NET.Test.Sdk (16.11)
+      Microsoft.CodeCoverage (>= 16.11)
+      Microsoft.TestPlatform.TestHost (>= 16.11)
+    Microsoft.TestPlatform.ObjectModel (18.3)
+      System.Reflection.Metadata (>= 8.0)
+    Microsoft.TestPlatform.TestHost (18.3)
+      Microsoft.TestPlatform.ObjectModel (>= 18.3)
+      Newtonsoft.Json (>= 13.0.3)
+    Newtonsoft.Json (13.0.4)
+    System.Reflection.Metadata (10.0.5)
     xunit (2.9.3)
       xunit.analyzers (>= 1.18)
       xunit.assert (>= 2.9.3)

--- a/paket.lock
+++ b/paket.lock
@@ -1,5 +1,5 @@
 STORAGE: NONE
-RESTRICTION: == net10.0
+RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Fable.Core (5.0.0-rc.1)
@@ -8,23 +8,13 @@ NUGET
 
 GROUP Test
 STORAGE: NONE
-RESTRICTION: == net10.0
+RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
-    Microsoft.CodeCoverage (18.3)
     Microsoft.NET.Test.Sdk (16.11)
-      Microsoft.CodeCoverage (>= 16.11)
-      Microsoft.TestPlatform.TestHost (>= 16.11)
-    Microsoft.TestPlatform.ObjectModel (18.3)
-      System.Reflection.Metadata (>= 8.0)
-    Microsoft.TestPlatform.TestHost (18.3)
-      Microsoft.TestPlatform.ObjectModel (>= 18.3)
-      Newtonsoft.Json (>= 13.0.3)
-    Newtonsoft.Json (13.0.4)
-    System.Reflection.Metadata (10.0.4)
     xunit (2.9.3)
       xunit.analyzers (>= 1.18)
       xunit.assert (>= 2.9.3)

--- a/src/Fable.Beam.fsproj
+++ b/src/Fable.Beam.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Author>Dag Brattli</Author>
     <Copyright>Dag Brattli</Copyright>

--- a/src/cowboy/Fable.Beam.Cowboy.fsproj
+++ b/src/cowboy/Fable.Beam.Cowboy.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Author>Dag Brattli</Author>
     <Copyright>Dag Brattli</Copyright>

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>


### PR DESCRIPTION
## Summary
- Change target framework from `net10.0` to `netstandard2.0` in both `Fable.Beam.fsproj` and `Fable.Beam.Cowboy.fsproj`
- Fable plugins need to target netstandard2.0 for compatibility

## Test plan
- [ ] Verify packages build correctly with netstandard2.0
- [ ] Verify Fable can load the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)