### PR TITLE
feat: add erased opaque types for Erlang Pid, Ref, Atom, TimerRef and TableId

### DIFF
--- a/src/otp/Application.fs
+++ b/src/otp/Application.fs
@@ -3,23 +3,24 @@
 module Fable.Beam.Application
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
 [<Erase>]
 type IExports =
     /// Starts an application and all its dependencies.
-    abstract ensure_all_started: app: obj -> obj
+    abstract ensure_all_started: app: Atom -> obj
     /// Starts an application.
-    abstract start: app: obj -> obj
+    abstract start: app: Atom -> obj
     /// Stops an application.
-    abstract stop: app: obj -> obj
+    abstract stop: app: Atom -> obj
     /// Gets an application environment variable.
-    abstract get_env: app: obj * key: obj -> obj
+    abstract get_env: app: Atom * key: Atom -> obj
     /// Gets an application environment variable with default.
-    abstract get_env: app: obj * key: obj * defaultValue: obj -> obj
+    abstract get_env: app: Atom * key: Atom * defaultValue: obj -> obj
     /// Sets an application environment variable.
-    abstract set_env: app: obj * key: obj * value: obj -> obj
+    abstract set_env: app: Atom * key: Atom * value: obj -> obj
     /// Returns a list of all running applications.
     abstract which_applications: unit -> obj
 

--- a/src/otp/Erlang.fs
+++ b/src/otp/Erlang.fs
@@ -8,24 +8,44 @@ open Fable.Core
 // which is provided by Fable.Core and handled by the compiler.
 
 // ============================================================================
+// Opaque Erlang types
+// ============================================================================
+
+/// Erlang process identifier.
+[<Erase>]
+type Pid = Pid of obj
+
+/// Erlang reference (from make_ref, monitor, etc.).
+[<Erase>]
+type Ref = Ref of obj
+
+/// Erlang atom.
+[<Erase>]
+type Atom = Atom of obj
+
+/// Erlang timer reference (from send_after, etc.).
+[<Erase>]
+type TimerRef = TimerRef of obj
+
+// ============================================================================
 // Process management
 // ============================================================================
 
 /// Get the current process's pid.
 [<Emit("erlang:self()")>]
-let self () : obj = nativeOnly
+let self () : Pid = nativeOnly
 
 /// Spawn a new process that executes the given function.
 [<Emit("erlang:spawn(fun() -> $0(ok) end)")>]
-let spawn (f: unit -> unit) : obj = nativeOnly
+let spawn (f: unit -> unit) : Pid = nativeOnly
 
 /// Spawn a linked process.
 [<Emit("erlang:spawn_link(fun() -> $0(ok) end)")>]
-let spawnLink (f: unit -> unit) : obj = nativeOnly
+let spawnLink (f: unit -> unit) : Pid = nativeOnly
 
 /// Send a message to a process (Pid ! Msg).
 [<Emit("$0 ! $1")>]
-let send (pid: obj) (msg: obj) : unit = nativeOnly
+let send (pid: Pid) (msg: obj) : unit = nativeOnly
 
 /// Enable trap_exit so EXIT signals become messages.
 [<Emit("erlang:process_flag(trap_exit, true)")>]
@@ -33,7 +53,7 @@ let trapExit () : unit = nativeOnly
 
 /// Set a process flag.
 [<Emit("erlang:process_flag($0, $1)")>]
-let processFlag (flag: obj) (value: obj) : obj = nativeOnly
+let processFlag (flag: Atom) (value: obj) : obj = nativeOnly
 
 /// Exit the current process with a reason.
 [<Emit("erlang:exit($0)")>]
@@ -41,39 +61,39 @@ let exit (reason: obj) : unit = nativeOnly
 
 /// Send an exit signal to a process.
 [<Emit("erlang:exit($0, $1)")>]
-let exitPid (pid: obj) (reason: obj) : unit = nativeOnly
+let exitPid (pid: Pid) (reason: obj) : unit = nativeOnly
 
 /// Link to another process.
 [<Emit("erlang:link($0)")>]
-let link (pid: obj) : unit = nativeOnly
+let link (pid: Pid) : unit = nativeOnly
 
 /// Unlink from a process.
 [<Emit("erlang:unlink($0)")>]
-let unlink (pid: obj) : unit = nativeOnly
+let unlink (pid: Pid) : unit = nativeOnly
 
 /// Monitor a process. Returns a monitor reference.
 [<Emit("erlang:monitor(process, $0)")>]
-let monitor (pid: obj) : obj = nativeOnly
+let monitor (pid: Pid) : Ref = nativeOnly
 
 /// Demonitor a process.
 [<Emit("erlang:demonitor($0)")>]
-let demonitor (ref: obj) : unit = nativeOnly
+let demonitor (ref: Ref) : unit = nativeOnly
 
 /// Demonitor a process with flush option.
 [<Emit("erlang:demonitor($0, [flush])")>]
-let demonitorFlush (ref: obj) : unit = nativeOnly
+let demonitorFlush (ref: Ref) : unit = nativeOnly
 
 /// Register a name for the calling process.
 [<Emit("erlang:register($0, $1)")>]
-let register (name: obj) (pid: obj) : unit = nativeOnly
+let register (name: Atom) (pid: Pid) : unit = nativeOnly
 
 /// Look up a registered process name.
 [<Emit("erlang:whereis($0)")>]
-let whereis (name: obj) : obj = nativeOnly
+let whereis (name: Atom) : Pid = nativeOnly
 
 /// Check if a process is alive.
 [<Emit("erlang:is_process_alive($0)")>]
-let isProcessAlive (pid: obj) : bool = nativeOnly
+let isProcessAlive (pid: Pid) : bool = nativeOnly
 
 // ============================================================================
 // References and identity
@@ -81,7 +101,7 @@ let isProcessAlive (pid: obj) : bool = nativeOnly
 
 /// Create a unique reference.
 [<Emit("erlang:make_ref()")>]
-let makeRef () : obj = nativeOnly
+let makeRef () : Ref = nativeOnly
 
 /// Exact equality comparison (=:=).
 [<Emit("$0 =:= $1")>]
@@ -97,15 +117,15 @@ let monotonicTimeMs () : int = nativeOnly
 
 /// Get system time in the given unit.
 [<Emit("erlang:system_time($0)")>]
-let systemTime (unit: obj) : int = nativeOnly
+let systemTime (unit: Atom) : int = nativeOnly
 
 /// Schedule a message to be sent after Ms milliseconds.
 [<Emit("erlang:send_after($0, erlang:self(), $1)")>]
-let sendAfter (ms: int) (msg: obj) : obj = nativeOnly
+let sendAfter (ms: int) (msg: obj) : TimerRef = nativeOnly
 
 /// Cancel a timer.
 [<Emit("erlang:cancel_timer($0)")>]
-let cancelTimer (timerRef: obj) : unit = nativeOnly
+let cancelTimer (timerRef: TimerRef) : unit = nativeOnly
 
 // ============================================================================
 // Process dictionary
@@ -163,19 +183,19 @@ let listToBinary (list: obj) : obj = nativeOnly
 
 /// Convert an atom to a binary string.
 [<Emit("erlang:atom_to_binary($0)")>]
-let atomToBinary (atom: obj) : string = nativeOnly
+let atomToBinary (atom: Atom) : string = nativeOnly
 
 /// Convert a binary string to an atom.
 [<Emit("erlang:binary_to_atom($0)")>]
-let binaryToAtom (s: string) : obj = nativeOnly
+let binaryToAtom (s: string) : Atom = nativeOnly
 
 /// Convert an atom to a list (charlist).
 [<Emit("erlang:atom_to_list($0)")>]
-let atomToList (atom: obj) : string = nativeOnly
+let atomToList (atom: Atom) : string = nativeOnly
 
 /// Convert a list (charlist) to an atom.
 [<Emit("erlang:list_to_atom($0)")>]
-let listToAtom (s: string) : obj = nativeOnly
+let listToAtom (s: string) : Atom = nativeOnly
 
 /// Format a term as a readable string.
 [<Emit("erlang:list_to_binary(io_lib:format(<<\"~p\">>, [$0]))")>]

--- a/src/otp/Ets.fs
+++ b/src/otp/Ets.fs
@@ -3,33 +3,38 @@
 module Fable.Beam.Ets
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
+
+/// Opaque ETS table identifier.
+[<Erase>]
+type TableId = TableId of obj
 
 [<Erase>]
 type IExports =
     /// Creates a new ETS table.
-    abstract new_: name: obj * options: obj list -> obj
+    abstract new_: name: Atom * options: obj list -> TableId
     /// Inserts a tuple or list of tuples into the table.
-    abstract insert: table: obj * objects: obj -> bool
+    abstract insert: table: TableId * objects: obj -> bool
     /// Looks up elements with the given key.
-    abstract lookup: table: obj * key: obj -> obj array
+    abstract lookup: table: TableId * key: obj -> obj array
     /// Deletes an entire table.
-    abstract delete: table: obj -> unit
+    abstract delete: table: TableId -> unit
     /// Deletes all objects with key from the table.
-    abstract delete: table: obj * key: obj -> unit
+    abstract delete: table: TableId * key: obj -> unit
     /// Returns a list of all objects in the table.
-    abstract tab2list: table: obj -> obj array
+    abstract tab2list: table: TableId -> obj array
     /// Returns information about the table.
-    abstract info: table: obj -> obj
+    abstract info: table: TableId -> obj
     /// Matches objects in the table against a pattern.
-    abstract ``match``: table: obj * pattern: obj -> obj array
+    abstract ``match``: table: TableId * pattern: obj -> obj array
     /// Selects objects using a match specification.
-    abstract select: table: obj * matchSpec: obj -> obj array
+    abstract select: table: TableId * matchSpec: obj -> obj array
     /// Returns the first key in the table.
-    abstract first: table: obj -> obj
+    abstract first: table: TableId -> obj
     /// Returns the next key after the given key.
-    abstract next: table: obj * key: obj -> obj
+    abstract next: table: TableId * key: obj -> obj
 
 /// ets module
 [<ImportAll("ets")>]

--- a/src/otp/GenServer.fs
+++ b/src/otp/GenServer.fs
@@ -3,15 +3,16 @@
 module Fable.Beam.GenServer
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
 [<Erase>]
 type IExports =
     /// Starts a gen_server process.
-    abstract start_link: ``module``: obj * args: obj * options: obj -> obj
+    abstract start_link: ``module``: Atom * args: obj * options: obj -> obj
     /// Starts a gen_server without linking.
-    abstract start: ``module``: obj * args: obj * options: obj -> obj
+    abstract start: ``module``: Atom * args: obj * options: obj -> obj
     /// Makes a synchronous call to a gen_server.
     abstract call: serverRef: obj * request: obj -> obj
     /// Makes a synchronous call with timeout.

--- a/src/otp/Io.fs
+++ b/src/otp/Io.fs
@@ -3,6 +3,7 @@
 module Fable.Beam.Io
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
@@ -11,7 +12,7 @@ type IExports =
     /// Writes a formatted string to standard output.
     abstract format: format: string * args: obj list -> unit
     /// Writes a formatted string to a device.
-    abstract format: device: obj * format: string * args: obj list -> unit
+    abstract format: device: Pid * format: string * args: obj list -> unit
     /// Reads a line from standard input.
     abstract get_line: prompt: string -> string
     /// Writes output to standard output.

--- a/src/otp/Supervisor.fs
+++ b/src/otp/Supervisor.fs
@@ -3,15 +3,16 @@
 module Fable.Beam.Supervisor
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
 [<Erase>]
 type IExports =
     /// Starts a supervisor process.
-    abstract start_link: ``module``: obj * args: obj -> obj
+    abstract start_link: ``module``: Atom * args: obj -> obj
     /// Starts a named supervisor process.
-    abstract start_link: name: obj * ``module``: obj * args: obj -> obj
+    abstract start_link: name: obj * ``module``: Atom * args: obj -> obj
     /// Dynamically adds a child specification to a supervisor.
     abstract start_child: supRef: obj * childSpec: obj -> obj
     /// Terminates a child process.

--- a/src/otp/Timer.fs
+++ b/src/otp/Timer.fs
@@ -3,21 +3,22 @@
 module Fable.Beam.Timer
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
 [<Erase>]
 type IExports =
     /// Sends Msg to Dest after Time milliseconds.
-    abstract send_after: time: int * dest: obj * msg: obj -> obj
+    abstract send_after: time: int * dest: Pid * msg: obj -> TimerRef
     /// Sends Msg to Dest repeatedly every Time milliseconds.
-    abstract send_interval: time: int * dest: obj * msg: obj -> obj
+    abstract send_interval: time: int * dest: Pid * msg: obj -> TimerRef
     /// Evaluates Fun after Time milliseconds.
-    abstract apply_after: time: int * ``module``: obj * ``function``: obj * args: obj list -> obj
+    abstract apply_after: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> TimerRef
     /// Evaluates Fun repeatedly every Time milliseconds.
-    abstract apply_interval: time: int * ``module``: obj * ``function``: obj * args: obj list -> obj
+    abstract apply_interval: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> TimerRef
     /// Cancels a previously started timer.
-    abstract cancel: timerRef: obj -> obj
+    abstract cancel: timerRef: TimerRef -> obj
     /// Suspends the process for Time milliseconds.
     abstract sleep: time: int -> unit
     /// Converts hours to milliseconds.

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -8,6 +8,7 @@
     <LangVersion>preview</LangVersion>
     <OutputType>Exe</OutputType>
     <NoWarn>NU1510</NoWarn>
+    <DefineConstants>FABLE_COMPILER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Fable.Beam.fsproj" />

--- a/test/TestErlang.fs
+++ b/test/TestErlang.fs
@@ -45,7 +45,7 @@ let ``test exactEquals on same ref`` () =
 let ``test spawn creates a process`` () =
 #if FABLE_COMPILER
     let pid = spawn (fun () -> ())
-    pid |> notEqual null
+    isProcessAlive pid |> equal true
 #else
     ()
 #endif
@@ -54,7 +54,7 @@ let ``test spawn creates a process`` () =
 let ``test spawnLink creates a linked process`` () =
 #if FABLE_COMPILER
     let pid = spawnLink (fun () -> ())
-    pid |> notEqual null
+    isProcessAlive pid |> equal true
 #else
     ()
 #endif


### PR DESCRIPTION
## Summary
- Define `Pid`, `Ref`, `Atom`, `TimerRef` as `[<Erase>]` single-case DUs in `Erlang.fs`, and `TableId` in `Ets.fs`
- Replace bare `obj` with these opaque types across OTP bindings (GenServer, Supervisor, Timer, Application, Io, Ets)
- Keep `serverRef`/`supRef` as `obj` since Erlang accepts pid, atom, or tuple for those
- Define `FABLE_COMPILER` in test fsproj so Ionide can introspect `#if FABLE_COMPILER` blocks
- Fix spawn/spawnLink tests to use `isProcessAlive` instead of null checks

## Test plan
- [x] `dotnet build` succeeds for all three projects (0 warnings, 0 errors)
- [x] `just test` passes all 44 Erlang tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)