### PR TITLE
fix: make Httpc public functions direct Emit bindings

### DIFF
--- a/src/otp/Httpc.fs
+++ b/src/otp/Httpc.fs
@@ -36,25 +36,31 @@ let verifyPeer: SslOptions = nativeOnly
 let verifyPeerCaFile (caFile: string) : SslOptions = nativeOnly
 
 // ============================================================================
-// Internal helpers
+// Public API
 // ============================================================================
 // WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
 // Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+//
+// All public functions are direct Emit bindings (not wrappers around private
+// functions) because Fable compiles cross-module non-Emit calls as Erlang
+// module calls (e.g. httpc:get/3), which don't exist in Erlang's httpc module.
 
+/// Performs an HTTP GET request.
 [<Emit("""
 (fun() ->
     Url = binary_to_list($0),
     Headers = [{binary_to_list(K), binary_to_list(V)} || {K, V} <- $1],
     case httpc:request(get, {Url, Headers}, $2, []) of
         {ok, {{_, StatusCode, _}, _RespHeaders, Body}} ->
-            {ok, {StatusCode, erlang:list_to_binary(Body)}};
+            {ok, #{statusCode => StatusCode, body => erlang:list_to_binary(Body)}};
         {error, Reason} ->
             {error, erlang:list_to_binary(io_lib:format(<<"~p">>, [Reason]))}
     end
 end)()
 """)>]
-let private getRaw (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<int * string, string> = nativeOnly
+let get (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<HttpResponse, string> = nativeOnly
 
+/// Performs an HTTP POST request with a content type and body.
 [<Emit("""
 (fun() ->
     Url = binary_to_list($0),
@@ -63,14 +69,15 @@ let private getRaw (url: string) (headers: (string * string) list) (ssl: SslOpti
     ReqBody = $3,
     case httpc:request(post, {Url, Headers, ContentType, ReqBody}, $4, []) of
         {ok, {{_, StatusCode, _}, _RespHeaders, Body}} ->
-            {ok, {StatusCode, erlang:list_to_binary(Body)}};
+            {ok, #{statusCode => StatusCode, body => erlang:list_to_binary(Body)}};
         {error, Reason} ->
             {error, erlang:list_to_binary(io_lib:format(<<"~p">>, [Reason]))}
     end
 end)()
 """)>]
-let private postRaw (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<int * string, string> = nativeOnly
+let post (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<HttpResponse, string> = nativeOnly
 
+/// Performs an HTTP PUT request with a content type and body.
 [<Emit("""
 (fun() ->
     Url = binary_to_list($0),
@@ -79,47 +86,25 @@ let private postRaw (url: string) (headers: (string * string) list) (contentType
     ReqBody = $3,
     case httpc:request(put, {Url, Headers, ContentType, ReqBody}, $4, []) of
         {ok, {{_, StatusCode, _}, _RespHeaders, Body}} ->
-            {ok, {StatusCode, erlang:list_to_binary(Body)}};
+            {ok, #{statusCode => StatusCode, body => erlang:list_to_binary(Body)}};
         {error, Reason} ->
             {error, erlang:list_to_binary(io_lib:format(<<"~p">>, [Reason]))}
     end
 end)()
 """)>]
-let private putRaw (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<int * string, string> = nativeOnly
+let put (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<HttpResponse, string> = nativeOnly
 
+/// Performs an HTTP DELETE request.
 [<Emit("""
 (fun() ->
     Url = binary_to_list($0),
     Headers = [{binary_to_list(K), binary_to_list(V)} || {K, V} <- $1],
     case httpc:request(delete, {Url, Headers}, $2, []) of
         {ok, {{_, StatusCode, _}, _RespHeaders, Body}} ->
-            {ok, {StatusCode, erlang:list_to_binary(Body)}};
+            {ok, #{statusCode => StatusCode, body => erlang:list_to_binary(Body)}};
         {error, Reason} ->
             {error, erlang:list_to_binary(io_lib:format(<<"~p">>, [Reason]))}
     end
 end)()
 """)>]
-let private deleteRaw (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<int * string, string> = nativeOnly
-
-let private toResponse (result: Result<int * string, string>) : Result<HttpResponse, string> =
-    result |> Result.map (fun (code, body) -> { StatusCode = code; Body = body })
-
-// ============================================================================
-// Public API
-// ============================================================================
-
-/// Performs an HTTP GET request.
-let get (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<HttpResponse, string> =
-    getRaw url headers ssl |> toResponse
-
-/// Performs an HTTP POST request with a content type and body.
-let post (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<HttpResponse, string> =
-    postRaw url headers contentType body ssl |> toResponse
-
-/// Performs an HTTP PUT request with a content type and body.
-let put (url: string) (headers: (string * string) list) (contentType: string) (body: string) (ssl: SslOptions) : Result<HttpResponse, string> =
-    putRaw url headers contentType body ssl |> toResponse
-
-/// Performs an HTTP DELETE request.
-let delete (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<HttpResponse, string> =
-    deleteRaw url headers ssl |> toResponse
+let delete (url: string) (headers: (string * string) list) (ssl: SslOptions) : Result<HttpResponse, string> = nativeOnly


### PR DESCRIPTION
## Summary
- Fable compiles cross-module non-Emit wrapper functions as Erlang module calls (e.g. `httpc:get/3`), but Erlang's `httpc` module only has `httpc:request/4` — causing runtime errors
- Make `get`, `post`, `put`, `delete` direct `[<Emit>]` bindings that return `HttpResponse` maps from the Erlang code, removing the private `*Raw` helpers and `toResponse` wrapper

## Test plan
- [ ] `just test` passes
- [ ] Verify cross-module calls to `Httpc.get`/`Httpc.post` from another project compile to correct `httpc:request` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)