### PR TITLE
fix: strip package name prefix from version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
           MESSAGE="${{ github.event.head_commit.message }}"
           VERSION="${MESSAGE#chore: release }"
           VERSION="${VERSION%% *}"
+          # Strip package name prefix (e.g. Fable.Beam@1.0.0-rc.7 -> 1.0.0-rc.7)
+          VERSION="${VERSION##*@}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- ShipIt 2.0 with a `name` field in CHANGELOG.md generates commit messages like `chore: release Fable.Beam@5.0.0-rc.7`
- The version extraction in publish.yml didn't strip the `Fable.Beam@` prefix, passing an invalid version string to `dotnet pack`
- Same fix as https://github.com/dbrattli/Fable.Reactive/commit/8278b84

## Test plan
- [ ] Merge and verify next ShipIt release publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)