### PR TITLE
chore: release Fable.Beam@5.0.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 ---
-last_commit_released: 85efdcf8ad96af8a1b1406ccf275a8be41e39098
+last_commit_released: 032a984964a06351267b2ef5308e61ff5dcfaae5
 name: Fable.Beam
 ---
 
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 5.0.0-rc.9 - 2026-03-20
+
+### 🐞 Bug Fixes
+
+* Use snake_case keys in Httpc response maps (#18) ([032a984](https://github.com/fable-compiler/Fable.Beam/commit/032a984964a06351267b2ef5308e61ff5dcfaae5))
+
+<strong><small>[View changes on Github](https://github.com/fable-compiler/Fable.Beam/compare/85efdcf8ad96af8a1b1406ccf275a8be41e39098..032a984964a06351267b2ef5308e61ff5dcfaae5)</small></strong>
 
 ## 5.0.0-rc.8 - 2026-03-18
 


### PR DESCRIPTION
## 🤖 New versions available

| Project | Status | New Version |
| --- | :---: | :---: |
| Fable.Beam | 🚀 | 5.0.0-rc.9 |

**Legend:**
- ✅ No version bump required
- 🚀 New version

## Fable.Beam

### 5.0.0-rc.9 - 2026-03-20

#### 🐞 Bug Fixes

* Use snake_case keys in Httpc response maps (#18) ([032a984](https://github.com/fable-compiler/Fable.Beam/commit/032a984964a06351267b2ef5308e61ff5dcfaae5))

<strong><small>[View changes on Github](https://github.com/fable-compiler/Fable.Beam/compare/85efdcf8ad96af8a1b1406ccf275a8be41e39098..032a984964a06351267b2ef5308e61ff5dcfaae5)</small></strong>


---
This PR was created automatically by [EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt)