### PR TITLE
fix: rename generic Erlang variables in Emit expressions to avoid scope clashes

### DIFF
--- a/src/otp/File.fs
+++ b/src/otp/File.fs
@@ -47,36 +47,36 @@ let file: IExports = nativeOnly
 
 /// Reads the contents of a file. Handles binary_to_list conversion for path.
 /// Returns Ok with file contents as binary, or Error with reason as string.
-[<Emit("(fun() -> case file:read_file(binary_to_list($0)) of {ok, Data} -> {ok, Data}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:read_file(binary_to_list($0)) of {ok, FileReadData__} -> {ok, FileReadData__}; {error, FileReadReason__} -> {error, erlang:atom_to_binary(FileReadReason__)} end end)()")>]
 let readFile (path: string) : Result<string, string> = nativeOnly
 
 /// Writes data to a file. Handles binary_to_list conversion for path.
 /// Returns Ok unit or Error with reason as string.
-[<Emit("(fun() -> case file:write_file(binary_to_list($0), $1) of ok -> {ok, ok}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:write_file(binary_to_list($0), $1) of ok -> {ok, ok}; {error, FileWriteReason__} -> {error, erlang:atom_to_binary(FileWriteReason__)} end end)()")>]
 let writeFile (path: string) (data: string) : Result<unit, string> = nativeOnly
 
 /// Deletes a file. Handles binary_to_list conversion for path.
-[<Emit("(fun() -> case file:delete(binary_to_list($0)) of ok -> {ok, ok}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:delete(binary_to_list($0)) of ok -> {ok, ok}; {error, FileDeleteReason__} -> {error, erlang:atom_to_binary(FileDeleteReason__)} end end)()")>]
 let delete (path: string) : Result<unit, string> = nativeOnly
 
 /// Creates a directory. Handles binary_to_list conversion for path.
-[<Emit("(fun() -> case file:make_dir(binary_to_list($0)) of ok -> {ok, ok}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:make_dir(binary_to_list($0)) of ok -> {ok, ok}; {error, FileMkDirReason__} -> {error, erlang:atom_to_binary(FileMkDirReason__)} end end)()")>]
 let makeDir (path: string) : Result<unit, string> = nativeOnly
 
 /// Deletes a directory. Handles binary_to_list conversion for path.
-[<Emit("(fun() -> case file:del_dir(binary_to_list($0)) of ok -> {ok, ok}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:del_dir(binary_to_list($0)) of ok -> {ok, ok}; {error, FileDelDirReason__} -> {error, erlang:atom_to_binary(FileDelDirReason__)} end end)()")>]
 let delDir (path: string) : Result<unit, string> = nativeOnly
 
 /// Lists files in a directory. Converts charlist filenames to binaries.
-[<Emit("(fun() -> case file:list_dir(binary_to_list($0)) of {ok, Files} -> {ok, [erlang:list_to_binary(F) || F <- Files]}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:list_dir(binary_to_list($0)) of {ok, FileListFiles__} -> {ok, [erlang:list_to_binary(FileListF__) || FileListF__ <- FileListFiles__]}; {error, FileListReason__} -> {error, erlang:atom_to_binary(FileListReason__)} end end)()")>]
 let listDir (path: string) : Result<string list, string> = nativeOnly
 
 /// Renames (moves) a file. Handles binary_to_list conversion for both paths.
-[<Emit("(fun() -> case file:rename(binary_to_list($0), binary_to_list($1)) of ok -> {ok, ok}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:rename(binary_to_list($0), binary_to_list($1)) of ok -> {ok, ok}; {error, FileRenameReason__} -> {error, erlang:atom_to_binary(FileRenameReason__)} end end)()")>]
 let rename (source: string) (destination: string) : Result<unit, string> = nativeOnly
 
 /// Returns the current working directory as a binary string.
-[<Emit("(fun() -> case file:get_cwd() of {ok, Dir} -> {ok, erlang:list_to_binary(Dir)}; {error, Reason} -> {error, erlang:atom_to_binary(Reason)} end end)()")>]
+[<Emit("(fun() -> case file:get_cwd() of {ok, FileGetCwdDir__} -> {ok, erlang:list_to_binary(FileGetCwdDir__)}; {error, FileGetCwdReason__} -> {error, erlang:atom_to_binary(FileGetCwdReason__)} end end)()")>]
 let getCwd () : Result<string, string> = nativeOnly
 
 /// Checks if a file or directory exists at the given path.

--- a/src/otp/Io.fs
+++ b/src/otp/Io.fs
@@ -31,7 +31,7 @@ let io: IExports = nativeOnly
 /// Reads a line from standard input. Returns None on EOF (Ctrl+D),
 /// Some with the line (including trailing newline) otherwise.
 /// Handles the eof atom that io:get_line returns on end-of-input.
-[<Emit("(fun() -> case io:get_line($0) of eof -> undefined; Line -> erlang:list_to_binary(Line) end end)()")>]
+[<Emit("(fun() -> case io:get_line($0) of eof -> undefined; IoGetLine__ -> erlang:list_to_binary(IoGetLine__) end end)()")>]
 let getLine (prompt: string) : string option = nativeOnly
 
 /// Writes a string to standard output.

--- a/src/otp/Os.fs
+++ b/src/otp/Os.fs
@@ -15,7 +15,7 @@ open Fable.Core
 /// Gets an environment variable. Returns None if not set
 /// (os:getenv returns the atom `false` when unset).
 /// Handles binary_to_list/list_to_binary conversion.
-[<Emit("(fun() -> case os:getenv(binary_to_list($0)) of false -> undefined; Value -> erlang:list_to_binary(Value) end end)()")>]
+[<Emit("(fun() -> case os:getenv(binary_to_list($0)) of false -> undefined; OsGetEnv__ -> erlang:list_to_binary(OsGetEnv__) end end)()")>]
 let getenv (name: string) : string option = nativeOnly
 
 /// Sets an environment variable.


### PR DESCRIPTION
## Summary
- Renames generic Erlang variables (`Value`, `Line`, `Data`, `Reason`, `Files`, `Dir`, `F`) to unique prefixed names with `__` suffix across `Os.fs`, `Io.fs`, and `File.fs`
- Prevents potential variable name collisions in Fable-generated Erlang code, where generic names could clash with other bindings in the same scope

## Changed files
- **Os.fs**: `Value` → `OsGetEnv__`
- **Io.fs**: `Line` → `IoGetLine__`
- **File.fs**: `Data`/`Reason`/`Files`/`F`/`Dir` → per-function unique names (e.g., `FileReadData__`, `FileWriteReason__`, `FileListFiles__`, `FileGetCwdDir__`)

## Test plan
- [ ] Verify `Os.getenv`, `Io.getLine`, and all `File.*` functions behave correctly
- [ ] Confirm generated Erlang output uses the new uniquely-prefixed variable names for both `Io.fs` and `File.fs` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)