### PR TITLE
feat: add generic erased types and improve type safety across bindings

### DIFF
--- a/BINDINGS-GUIDE.md
+++ b/BINDINGS-GUIDE.md
@@ -18,11 +18,15 @@ When writing or reviewing a binding, check:
 
 ## Quick Reference
 
-|           Pattern           |                        When to use                         |          Example           |
-| --------------------------- | ---------------------------------------------------------- | -------------------------- |
-| `[<Emit>]`                  | BIFs, operators, inline Erlang code                        | `erlang:self()`, `$0 ! $1` |
-| `[<Erase>] + [<ImportAll>]` | Binding an Erlang module with multiple functions           | `timer`, `gen_server`      |
-| `[<Erase>]` on DU           | Opaque Erlang types (compile-time safety, no runtime cost) | `Pid`, `Ref`, `TableId`    |
+| Pattern | When to use | Example |
+| --- | --- | --- |
+| `[<Emit>]` | BIFs, operators, inline Erlang code | `erlang:self()`, `$0 ! $1` |
+| `[<Erase>] + [<ImportAll>]` | Binding an Erlang module with multiple functions | `timer`, `gen_server` |
+| `[<Erase>]` on DU | Opaque Erlang types (compile-time safety, no runtime cost) | `Pid`, `Ref`, `TableId` |
+| `[<Erase>]` on generic DU | Typed Erlang containers (maps, lists) | `BeamMap<'K,'V>`, `BeamList<'T>` |
+| `[<Emit>]` on abstract member | Override `ImportAll` codegen for specific methods | `fable_utils:new_ref(...)` wrapping |
+| `System.Func<>` / `System.Action` | Typed callbacks in `ImportAll` interfaces | `fold`, `filter`, `foreach` |
+| `U2<>` / `U3<>` / erased union | Parameters or returns that accept multiple types | timeout: `int` or `infinity` |
 
 ## Type Mappings: F# to Erlang
 
@@ -32,10 +36,10 @@ When writing or reviewing a binding, check:
 | `string`         | `binary()`                  | `<<"hello">>` — **not** charlists          |
 | `bool`           | `true` \| `false`           | Atoms                                      |
 | `unit`           | `ok`                        | Atom                                       |
-| `tuple`          | `tuple`                     | `{A, B, C}` — direct mapping              |
+| `tuple`          | `tuple`                     | `{A, B, C}` — direct mapping               |
 | `list<T>`        | `list()`                    | Both are linked lists                      |
 | `option<T>`      | value or `undefined`        | Erased wrapper                             |
-| `Result<T,E>`    | `{ok, V}` \| `{error, E}`  | Matches Erlang idiom                       |
+| `Result<T,E>`    | `{ok, V}` \| `{error, E}`   | Matches Erlang idiom                       |
 | `record`         | `map`                       | `#{field_name => Value}`                   |
 | DU (with fields) | tagged tuple                | `{tag, Field1, Field2}`                    |
 | DU (no fields)   | atom                        | `tag`                                      |
@@ -185,7 +189,9 @@ let monitor (pid: obj) : obj = nativeOnly
 
 ### Functions: use F# function types for callbacks
 
-When an Erlang function takes a fun/callback, use the appropriate F# function type:
+When an Erlang function takes a fun/callback, use the appropriate F# function type.
+
+For `[<Emit>]` bindings, use curried F# function types:
 
 ```fsharp
 /// Spawn a new process that executes the given function.
@@ -194,6 +200,72 @@ let spawn (f: unit -> unit) : Pid = nativeOnly
 ```
 
 Note: `unit` compiles to the atom `ok`, so `$0(ok)` calls the F# function with unit.
+
+For `[<ImportAll>]` interfaces, use `System.Func<>` and `System.Action<>`
+to type callback parameters. Fable compiles these to Erlang funs:
+
+```fsharp
+[<Erase>]
+type IExports =
+    /// Filters elements by a predicate.
+    abstract filter: pred: System.Func<'T, bool> * list: BeamList<'T> -> BeamList<'T>
+    /// Left fold over a list.
+    abstract foldl: f: System.Func<'T, 'Acc, 'Acc> * acc: 'Acc * list: BeamList<'T> -> 'Acc
+    /// Applies a function to each element for side effects.
+    abstract foreach: f: System.Action<'T> * list: BeamList<'T> -> unit
+    /// Applies a function to each key-value pair in a map.
+    abstract fold: f: System.Func<'K, 'V, 'Acc, 'Acc> * init: 'Acc * map: BeamMap<'K, 'V> -> 'Acc
+```
+
+Usage — pass an F# lambda wrapped in `System.Func`:
+
+```fsharp
+lists.filter (System.Func<_, _>(fun x -> x > 3), xs)
+lists.foldl (System.Func<_, _, _>(fun x acc -> acc + x), 0, xs)
+```
+
+### Erased unions: use for parameters or results with multiple types
+
+Erlang APIs sometimes accept or return values of different types. For
+example, a timeout might be an integer or the atom `infinity`, or a
+server ref might be a `Pid`, an `Atom`, or a `{global, Name}` tuple.
+
+Use `Fable.Core`'s erased union types (`U2`, `U3`, etc.) to express
+this without losing type safety:
+
+```fsharp
+open Fable.Core
+
+/// A gen_server timeout: either milliseconds or the atom 'infinity'.
+[<Erase>]
+type Timeout =
+    | Milliseconds of int
+    | Infinity of Atom
+
+    static member op_ErasedCast(x: int) = Milliseconds x
+    static member op_ErasedCast(x: Atom) = Infinity x
+```
+
+Or use the built-in `U2<'A, 'B>` / `U3<'A, 'B, 'C>` types directly:
+
+```fsharp
+[<Erase>]
+type IExports =
+    /// Call with a timeout that is either an int or the atom 'infinity'.
+    abstract call: serverRef: obj * request: obj * timeout: U2<int, Atom> -> obj
+```
+
+The `op_ErasedCast` static members enable implicit conversion, so
+callers can pass either type directly:
+
+```fsharp
+// Both work — the erased union accepts either type
+gen_server.call (ref, msg, !^ 5000)
+gen_server.call (ref, msg, !^ (Erlang.binaryToAtom "infinity"))
+```
+
+The `!^` operator triggers the erased cast. At the Erlang level,
+the value is passed through unchanged — no wrapping or tagging.
 
 ### When `obj` is acceptable
 
@@ -216,11 +288,14 @@ Is the Erlang type...
 ├── the atom 'ok'?         → unit
 ├── a fixed-size tuple?    → T1 * T2 * ...
 ├── a list of known type?  → T list (Emit) or T array (ImportAll)
+├── an Erlang list handle? → BeamList<T> (stays in Erlang list land)
+├── an Erlang map?         → BeamMap<K, V> (generic erased type)
 ├── {ok, V} | {error, R}? → Result<T, E>
 ├── value | sentinel?      → T option (return undefined for None)
 ├── a map with known keys? → F# record
 ├── an opaque handle?      → [<Erase>] type Foo = Foo of obj
-├── a callback fun?        → F# function type
+├── a callback fun?        → System.Func (ImportAll) or F# function (Emit)
+├── one of N known types?  → U2<A,B> / U3<A,B,C> or custom erased union
 └── genuinely dynamic?     → obj (last resort)
 ```
 
@@ -439,16 +514,55 @@ simple type alias:
 type Req = obj
 ```
 
+### Generic erased types
+
+For Erlang containers like maps and lists, use **generic** erased types
+to get compile-time type safety on keys, values, and elements:
+
+```fsharp
+/// Erlang map with typed keys and values.
+[<Erase>]
+type BeamMap<'K, 'V> = BeamMap of obj
+
+/// Erlang list with typed elements.
+[<Erase>]
+type BeamList<'T> = BeamList of obj
+```
+
+Use a `Beam` prefix to avoid confusion with F#'s built-in `Map` and
+`list` types. The generics exist only at compile time — at the Erlang
+level these are plain maps and lists with zero overhead.
+
+Then use the generic types throughout the interface:
+
+```fsharp
+[<Erase>]
+type IExports =
+    abstract new_: unit -> BeamMap<'K, 'V>
+    abstract get: key: 'K * map: BeamMap<'K, 'V> -> 'V
+    abstract put: key: 'K * value: 'V * map: BeamMap<'K, 'V> -> BeamMap<'K, 'V>
+    abstract is_key: key: 'K * map: BeamMap<'K, 'V> -> bool
+    abstract size: map: BeamMap<'K, 'V> -> int
+```
+
+Usage becomes fully typed — no `box` needed:
+
+```fsharp
+let m: BeamMap<string, int> = maps.new_ ()
+let m = maps.put ("key", 42, m)
+maps.get ("key", m) |> equal 42  // returns int, not obj
+```
+
 ## String and Atom Conversions
 
 F# strings compile to Erlang binaries (`<<"hello">>`), **not** charlists.
 Many OTP functions expect charlists, so you need to convert:
 
-|       Direction       |                      Emit code                      |
+|       Direction       |                      Emit code                       |
 | --------------------- | ---------------------------------------------------- |
 | F# string → charlist  | `binary_to_list($0)`                                 |
 | charlist → F# string  | `erlang:list_to_binary(...)`                         |
-| F# string → atom      | `binary_to_atom($0)` or `erlang:binary_to_atom($0)` |
+| F# string → atom      | `binary_to_atom($0)` or `erlang:binary_to_atom($0)`  |
 | atom → F# string      | `erlang:atom_to_binary($0)`                          |
 
 Example — an Erlang function that takes a charlist path and returns a
@@ -535,17 +649,46 @@ Erlang.
 
 ### Erlang lists vs F# arrays
 
-F# arrays on BEAM are ref-wrapped values in the process dictionary. Raw
-Erlang lists returned from OTP calls (e.g., `ets:tab2list/1`,
-`maps:keys/1`) are **not** ref-wrapped. This means F# `.Length` will
-not work on them. Use `Erlang.length` instead:
+F# arrays on BEAM are ref-wrapped values in the process dictionary
+(via `fable_utils:new_ref/1`). Raw Erlang lists returned from OTP calls
+(e.g., `ets:tab2list/1`, `maps:keys/1`) are **not** ref-wrapped. This
+means `Array.length` and other F# array operations will fail on raw
+Erlang lists.
+
+**Solution:** Use `[<Emit>]` on abstract members to wrap the return
+value with `fable_utils:new_ref()`, converting the Erlang list into a
+proper F# array. For the reverse direction, unwrap with `erlang:get()`:
 
 ```fsharp
-let all = ets.tab2list table
-// Don't: all.Length (fails at runtime)
-// Do:
-let count = Erlang.length (box all)
+[<Erase>]
+type IExports =
+    /// Returns keys as an F# array (wraps Erlang list with new_ref).
+    [<Emit("fable_utils:new_ref(maps:keys($0))")>]
+    abstract keys: map: BeamMap<'K, 'V> -> 'K array
+
+    /// Converts a map to key-value pairs as an F# array.
+    [<Emit("fable_utils:new_ref(maps:to_list($0))")>]
+    abstract to_list: map: BeamMap<'K, 'V> -> ('K * 'V) array
+
+    /// Converts an F# array of key-value pairs to a map (unwraps ref).
+    [<Emit("maps:from_list(erlang:get($0))")>]
+    abstract from_list: list: ('K * 'V) array -> BeamMap<'K, 'V>
 ```
+
+This allows standard F# array operations to work naturally:
+
+```fsharp
+maps.keys m |> Array.length |> equal 2       // works
+maps.to_list m |> Array.map fst              // works
+```
+
+Note: `[<Emit>]` on an abstract member overrides the `[<ImportAll>]`
+code generation for that specific method — other members still get the
+automatic `module:function(...)` calls.
+
+If you don't need F# array interop (e.g., the result stays in Erlang
+list land), use `BeamList<'T>` as the return type instead and skip the
+wrapping.
 
 ### ImportAll functions use tupled arguments
 

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ build:
 build-beam:
     dotnet build {{test_path}}
     {{fable}} {{test_path}} --lang Erlang --outDir {{build_path}}/tests
-    cp {{test_path}}/test_runner.erl {{build_path}}/tests/src/
+    cp {{test_path}}/test_runner.erl {{test_path}}/test_counter_server.erl {{build_path}}/tests/src/
     cd {{build_path}}/tests && rebar3 compile
 
 # Run BEAM tests (transpile F# to Erlang, compile, run on BEAM)

--- a/src/otp/Ets.fs
+++ b/src/otp/Ets.fs
@@ -14,22 +14,26 @@ type TableId = TableId of obj
 [<Erase>]
 type IExports =
     /// Creates a new ETS table.
-    abstract new_: name: Atom * options: obj list -> TableId
+    abstract new_: name: Atom * options: Atom list -> TableId
     /// Inserts a tuple or list of tuples into the table.
     abstract insert: table: TableId * objects: obj -> bool
     /// Looks up elements with the given key.
+    [<Emit("fable_utils:new_ref(ets:lookup($0, $1))")>]
     abstract lookup: table: TableId * key: obj -> obj array
     /// Deletes an entire table.
     abstract delete: table: TableId -> unit
     /// Deletes all objects with key from the table.
     abstract delete: table: TableId * key: obj -> unit
     /// Returns a list of all objects in the table.
+    [<Emit("fable_utils:new_ref(ets:tab2list($0))")>]
     abstract tab2list: table: TableId -> obj array
     /// Returns information about the table.
     abstract info: table: TableId -> obj
     /// Matches objects in the table against a pattern.
+    [<Emit("fable_utils:new_ref(ets:'match'($0, $1))")>]
     abstract ``match``: table: TableId * pattern: obj -> obj array
     /// Selects objects using a match specification.
+    [<Emit("fable_utils:new_ref(ets:select($0, $1))")>]
     abstract select: table: TableId * matchSpec: obj -> obj array
     /// Returns the first key in the table.
     abstract first: table: TableId -> obj

--- a/src/otp/GenServer.fs
+++ b/src/otp/GenServer.fs
@@ -7,28 +7,32 @@ open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
+/// A gen_server reference: Pid, registered name, or {global, Name}.
+[<Erase>]
+type ServerRef = ServerRef of obj
+
 [<Erase>]
 type IExports =
-    /// Starts a gen_server process. Returns {ok, Pid} | ignore | {error, Reason}.
-    abstract start_link: ``module``: Atom * args: obj * options: obj list -> obj
-    /// Starts a named gen_server process. Returns {ok, Pid} | ignore | {error, Reason}.
-    abstract start_link: name: obj * ``module``: Atom * args: obj * options: obj list -> obj
-    /// Starts a gen_server without linking. Returns {ok, Pid} | ignore | {error, Reason}.
-    abstract start: ``module``: Atom * args: obj * options: obj list -> obj
-    /// Starts a named gen_server without linking. Returns {ok, Pid} | ignore | {error, Reason}.
-    abstract start: name: obj * ``module``: Atom * args: obj * options: obj list -> obj
+    /// Starts a gen_server process.
+    abstract start_link: ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    /// Starts a named gen_server process.
+    abstract start_link: name: obj * ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    /// Starts a gen_server without linking.
+    abstract start: ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    /// Starts a named gen_server without linking.
+    abstract start: name: obj * ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
     /// Makes a synchronous call to a gen_server.
-    abstract call: serverRef: obj * request: obj -> obj
-    /// Makes a synchronous call with timeout. Use Erlang.binaryToAtom "infinity" for no timeout.
-    abstract call: serverRef: obj * request: obj * timeout: obj -> obj
+    abstract call: serverRef: ServerRef * request: obj -> obj
+    /// Makes a synchronous call with timeout (int ms or atom 'infinity').
+    abstract call: serverRef: ServerRef * request: obj * timeout: U2<int, Atom> -> obj
     /// Sends an asynchronous request to a gen_server.
-    abstract cast: serverRef: obj * request: obj -> unit
+    abstract cast: serverRef: ServerRef * request: obj -> unit
     /// Sends a reply to a client that called call/2,3.
     abstract reply: from: obj * reply: obj -> unit
     /// Stops a gen_server.
-    abstract stop: serverRef: obj -> unit
-    /// Stops a gen_server with reason and timeout. Use Erlang.binaryToAtom "infinity" for no timeout.
-    abstract stop: serverRef: obj * reason: obj * timeout: obj -> unit
+    abstract stop: serverRef: ServerRef -> unit
+    /// Stops a gen_server with reason and timeout (int ms or atom 'infinity').
+    abstract stop: serverRef: ServerRef * reason: Atom * timeout: U2<int, Atom> -> unit
 
 /// gen_server module
 [<ImportAll("gen_server")>]

--- a/src/otp/Lists.fs
+++ b/src/otp/Lists.fs
@@ -6,50 +6,54 @@ open Fable.Core
 
 // fsharplint:disable MemberNames
 
+/// Erlang list with typed elements.
+[<Erase>]
+type BeamList<'T> = BeamList of obj
+
 [<Erase>]
 type IExports =
     /// Appends two lists.
-    abstract append: list1: obj * list2: obj -> obj
+    abstract append: list1: BeamList<'T> * list2: BeamList<'T> -> BeamList<'T>
     /// Flattens a list of lists.
-    abstract flatten: deepList: obj -> obj
-    /// Returns the length of a list. Note: prefer erlang:length/1 for BIF performance.
-    abstract flatlength: list: obj -> int
+    abstract flatten: deepList: BeamList<BeamList<'T>> -> BeamList<'T>
+    /// Returns the length of a flat list. Note: prefer erlang:length/1 for BIF performance.
+    abstract flatlength: list: BeamList<'T> -> int
     /// Returns true if Elem is in the list.
-    abstract ``member``: elem: obj * list: obj -> bool
+    abstract ``member``: elem: 'T * list: BeamList<'T> -> bool
     /// Reverses a list.
-    abstract reverse: list: obj -> obj
+    abstract reverse: list: BeamList<'T> -> BeamList<'T>
     /// Sorts a list.
-    abstract sort: list: obj -> obj
+    abstract sort: list: BeamList<'T> -> BeamList<'T>
     /// Sorts a list using a comparison function.
-    abstract sort: f: obj * list: obj -> obj
+    abstract sort: f: System.Func<'T, 'T, bool> * list: BeamList<'T> -> BeamList<'T>
     /// Returns the Nth element (1-based).
-    abstract nth: n: int * list: obj -> obj
+    abstract nth: n: int * list: BeamList<'T> -> 'T
     /// Returns the last element.
-    abstract last: list: obj -> obj
+    abstract last: list: BeamList<'T> -> 'T
     /// Applies a function to each element (map).
-    abstract map: f: obj * list: obj -> obj
+    abstract map: f: System.Func<'T, 'U> * list: BeamList<'T> -> BeamList<'U>
     /// Filters elements by a predicate.
-    abstract filter: pred: obj * list: obj -> obj
+    abstract filter: pred: System.Func<'T, bool> * list: BeamList<'T> -> BeamList<'T>
     /// Left fold over a list.
-    abstract foldl: f: obj * acc: obj * list: obj -> obj
+    abstract foldl: f: System.Func<'T, 'Acc, 'Acc> * acc: 'Acc * list: BeamList<'T> -> 'Acc
     /// Right fold over a list.
-    abstract foldr: f: obj * acc: obj * list: obj -> obj
+    abstract foldr: f: System.Func<'T, 'Acc, 'Acc> * acc: 'Acc * list: BeamList<'T> -> 'Acc
     /// Applies a function to each element for side effects.
-    abstract foreach: f: obj * list: obj -> unit
+    abstract foreach: f: System.Action<'T> * list: BeamList<'T> -> unit
     /// Zips two lists into a list of tuples.
-    abstract zip: list1: obj * list2: obj -> obj
+    abstract zip: list1: BeamList<'A> * list2: BeamList<'B> -> BeamList<'A * 'B>
     /// Unzips a list of tuples into a tuple of two lists.
-    abstract unzip: list: obj -> obj * obj
+    abstract unzip: list: BeamList<'A * 'B> -> BeamList<'A> * BeamList<'B>
     /// Returns a tuple of {Satisfying, NotSatisfying} elements.
-    abstract partition: pred: obj * list: obj -> obj * obj
+    abstract partition: pred: System.Func<'T, bool> * list: BeamList<'T> -> BeamList<'T> * BeamList<'T>
     /// Removes duplicate elements.
-    abstract usort: list: obj -> obj
+    abstract usort: list: BeamList<'T> -> BeamList<'T>
     /// Returns a sublist (first N elements).
-    abstract sublist: list: obj * len: int -> obj
+    abstract sublist: list: BeamList<'T> * len: int -> BeamList<'T>
     /// Returns true if all elements satisfy the predicate.
-    abstract all: pred: obj * list: obj -> bool
+    abstract all: pred: System.Func<'T, bool> * list: BeamList<'T> -> bool
     /// Returns true if any element satisfies the predicate.
-    abstract any: pred: obj * list: obj -> bool
+    abstract any: pred: System.Func<'T, bool> * list: BeamList<'T> -> bool
 
 /// lists module
 [<ImportAll("lists")>]

--- a/src/otp/Maps.fs
+++ b/src/otp/Maps.fs
@@ -6,40 +6,48 @@ open Fable.Core
 
 // fsharplint:disable MemberNames
 
+/// Erlang map with typed keys and values.
+[<Erase>]
+type BeamMap<'K, 'V> = BeamMap of obj
+
 [<Erase>]
 type IExports =
     /// Returns a new empty map.
-    abstract new_: unit -> obj
+    abstract new_: unit -> BeamMap<'K, 'V>
     /// Gets the value associated with key.
-    abstract get: key: obj * map: obj -> obj
+    abstract get: key: 'K * map: BeamMap<'K, 'V> -> 'V
     /// Returns the value associated with key, or default if not found.
-    abstract get: key: obj * map: obj * ``default``: obj -> obj
+    abstract get: key: 'K * map: BeamMap<'K, 'V> * ``default``: 'V -> 'V
     /// Associates key with value in the map.
-    abstract put: key: obj * value: obj * map: obj -> obj
+    abstract put: key: 'K * value: 'V * map: BeamMap<'K, 'V> -> BeamMap<'K, 'V>
     /// Removes a key from the map.
-    abstract remove: key: obj * map: obj -> obj
+    abstract remove: key: 'K * map: BeamMap<'K, 'V> -> BeamMap<'K, 'V>
     /// Returns true if the map contains key.
-    abstract is_key: key: obj * map: obj -> bool
+    abstract is_key: key: 'K * map: BeamMap<'K, 'V> -> bool
     /// Returns a list of all keys in the map.
-    abstract keys: map: obj -> obj array
+    [<Emit("fable_utils:new_ref(maps:keys($0))")>]
+    abstract keys: map: BeamMap<'K, 'V> -> 'K array
     /// Returns a list of all values in the map.
-    abstract values: map: obj -> obj array
+    [<Emit("fable_utils:new_ref(maps:values($0))")>]
+    abstract values: map: BeamMap<'K, 'V> -> 'V array
     /// Returns the number of key-value pairs in the map.
-    abstract size: map: obj -> int
+    abstract size: map: BeamMap<'K, 'V> -> int
     /// Converts a list of key-value pairs to a map.
-    abstract from_list: list: obj -> obj
+    [<Emit("maps:from_list(erlang:get($0))")>]
+    abstract from_list: list: ('K * 'V) array -> BeamMap<'K, 'V>
     /// Converts a map to a list of key-value pairs.
-    abstract to_list: map: obj -> obj array
+    [<Emit("fable_utils:new_ref(maps:to_list($0))")>]
+    abstract to_list: map: BeamMap<'K, 'V> -> ('K * 'V) array
     /// Merges two maps.
-    abstract merge: map1: obj * map2: obj -> obj
+    abstract merge: map1: BeamMap<'K, 'V> * map2: BeamMap<'K, 'V> -> BeamMap<'K, 'V>
     /// Applies a function to each key-value pair.
-    abstract fold: f: obj * init: obj * map: obj -> obj
+    abstract fold: f: System.Func<'K, 'V, 'Acc, 'Acc> * init: 'Acc * map: BeamMap<'K, 'V> -> 'Acc
     /// Applies a function to each value, returning a new map.
-    abstract map: f: obj * map: obj -> obj
+    abstract map: f: System.Func<'K, 'V, 'V2> * map: BeamMap<'K, 'V> -> BeamMap<'K, 'V2>
     /// Filters key-value pairs by a predicate.
-    abstract filter: pred: obj * map: obj -> obj
+    abstract filter: pred: System.Func<'K, 'V, bool> * map: BeamMap<'K, 'V> -> BeamMap<'K, 'V>
     /// Returns {ok, Value} if key is in the map, or the atom error if not.
-    abstract find: key: obj * map: obj -> obj
+    abstract find: key: 'K * map: BeamMap<'K, 'V> -> obj
 
 /// maps module
 [<ImportAll("maps")>]

--- a/src/otp/Timer.fs
+++ b/src/otp/Timer.fs
@@ -9,16 +9,16 @@ open Fable.Beam.Erlang
 
 [<Erase>]
 type IExports =
-    /// Sends Msg to Dest after Time milliseconds. Returns {ok, TRef} | {error, Reason}.
-    abstract send_after: time: int * dest: Pid * msg: obj -> obj
-    /// Sends Msg to Dest repeatedly every Time milliseconds. Returns {ok, TRef} | {error, Reason}.
-    abstract send_interval: time: int * dest: Pid * msg: obj -> obj
-    /// Evaluates Fun after Time milliseconds. Returns {ok, TRef} | {error, Reason}.
-    abstract apply_after: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> obj
-    /// Evaluates Fun repeatedly every Time milliseconds. Returns {ok, TRef} | {error, Reason}.
-    abstract apply_interval: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> obj
-    /// Cancels a previously started timer. Returns {ok, cancel} | {error, Reason}.
-    abstract cancel: timerRef: TimerRef -> obj
+    /// Sends Msg to Dest after Time milliseconds.
+    abstract send_after: time: int * dest: Pid * msg: obj -> Result<TimerRef, Atom>
+    /// Sends Msg to Dest repeatedly every Time milliseconds.
+    abstract send_interval: time: int * dest: Pid * msg: obj -> Result<TimerRef, Atom>
+    /// Evaluates Fun after Time milliseconds.
+    abstract apply_after: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef, Atom>
+    /// Evaluates Fun repeatedly every Time milliseconds.
+    abstract apply_interval: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef, Atom>
+    /// Cancels a previously started timer.
+    abstract cancel: timerRef: TimerRef -> Result<Atom, Atom>
     /// Suspends the process for Time milliseconds.
     abstract sleep: time: int -> unit
     /// Converts hours to milliseconds.

--- a/test/TestEts.fs
+++ b/test/TestEts.fs
@@ -7,15 +7,12 @@ open Fable.Core
 open Fable.Core.BeamInterop
 open Fable.Beam.Ets
 open Fable.Beam.Erlang
-
-[<Emit("erlang:length($0)")>]
-let erlLength (xs: obj) : int = nativeOnly
 #endif
 
 [<Fact>]
 let ``test ets create and delete`` () =
 #if FABLE_COMPILER
-    let table = ets.new_ (binaryToAtom "test_table", [ box (binaryToAtom "set") ])
+    let table = ets.new_ (binaryToAtom "test_table", [ binaryToAtom "set" ])
     ets.delete table
 #else
     ()
@@ -24,11 +21,11 @@ let ``test ets create and delete`` () =
 [<Fact>]
 let ``test ets insert and lookup`` () =
 #if FABLE_COMPILER
-    let table = ets.new_ (binaryToAtom "lookup_table", [ box (binaryToAtom "set") ])
+    let table = ets.new_ (binaryToAtom "lookup_table", [ binaryToAtom "set" ])
     let tuple: obj = emitErlExpr () "{1, <<\"hello\">>}"
     ets.insert (table, tuple) |> equal true
     let result = ets.lookup (table, box 1)
-    erlLength (box result) |> equal 1
+    Array.length result |> equal 1
     ets.delete table
 #else
     ()
@@ -37,13 +34,13 @@ let ``test ets insert and lookup`` () =
 [<Fact>]
 let ``test ets tab2list`` () =
 #if FABLE_COMPILER
-    let table = ets.new_ (binaryToAtom "list_table", [ box (binaryToAtom "set") ])
+    let table = ets.new_ (binaryToAtom "list_table", [ binaryToAtom "set" ])
     let t1: obj = emitErlExpr () "{1, <<\"a\">>}"
     let t2: obj = emitErlExpr () "{2, <<\"b\">>}"
     ets.insert (table, t1) |> ignore
     ets.insert (table, t2) |> ignore
     let all = ets.tab2list table
-    erlLength (box all) |> equal 2
+    Array.length all |> equal 2
     ets.delete table
 #else
     ()

--- a/test/TestGenServer.fs
+++ b/test/TestGenServer.fs
@@ -3,6 +3,9 @@ module Fable.Beam.Tests.GenServer
 open Fable.Beam.Testing
 
 #if FABLE_COMPILER
+open Fable.Core
+open Fable.Core.BeamInterop
+open Fable.Beam.Erlang
 open Fable.Beam.GenServer
 #endif
 
@@ -10,9 +13,115 @@ open Fable.Beam.GenServer
 let ``test gen_server.stop on non-existent catches error`` () =
 #if FABLE_COMPILER
     try
-        gen_server.stop (box "nonexistent_process_xyz")
+        gen_server.stop (ServerRef "nonexistent_process_xyz")
     with
     | _ -> ()
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.start_link returns ok with pid`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start_link (binaryToAtom "test_counter_server", box 0, [])
+    match result with
+    | Ok pid -> isProcessAlive pid |> equal true
+    | Error _ -> failwith "start_link should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.start returns ok with pid`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 0, [])
+    match result with
+    | Ok pid ->
+        isProcessAlive pid |> equal true
+        gen_server.stop (ServerRef pid)
+    | Error _ -> failwith "start should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.call gets state`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 42, [])
+    match result with
+    | Ok pid ->
+        let value = gen_server.call (ServerRef pid, box (binaryToAtom "get"))
+        exactEquals value (box 42) |> equal true
+        gen_server.stop (ServerRef pid)
+    | Error _ -> failwith "start should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.call increment`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 0, [])
+    match result with
+    | Ok pid ->
+        let ref = ServerRef pid
+        let v1 = gen_server.call (ref, box (binaryToAtom "increment"))
+        exactEquals v1 (box 1) |> equal true
+        let v2 = gen_server.call (ref, box (binaryToAtom "increment"))
+        exactEquals v2 (box 2) |> equal true
+        gen_server.stop ref
+    | Error _ -> failwith "start should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.call with timeout`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 10, [])
+    match result with
+    | Ok pid ->
+        let ref = ServerRef pid
+        let value = gen_server.call (ref, box (binaryToAtom "get"), U2.Case1 5000)
+        exactEquals value (box 10) |> equal true
+        gen_server.stop ref
+    | Error _ -> failwith "start should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.cast updates state`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 0, [])
+    match result with
+    | Ok pid ->
+        let ref = ServerRef pid
+        let setMsg: obj = emitErlExpr () "{set, 99}"
+        gen_server.cast (ref, setMsg)
+        // Small delay to let cast process
+        Fable.Beam.Timer.sleep 10
+        let value = gen_server.call (ref, box (binaryToAtom "get"))
+        exactEquals value (box 99) |> equal true
+        gen_server.stop ref
+    | Error _ -> failwith "start should succeed"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test gen_server.stop with reason and timeout`` () =
+#if FABLE_COMPILER
+    let result = gen_server.start (binaryToAtom "test_counter_server", box 0, [])
+    match result with
+    | Ok pid ->
+        let ref = ServerRef pid
+        isProcessAlive pid |> equal true
+        gen_server.stop (ref, binaryToAtom "normal", U2.Case1 5000)
+        // Process should be dead after stop
+        Fable.Beam.Timer.sleep 10
+        isProcessAlive pid |> equal false
+    | Error _ -> failwith "start should succeed"
 #else
     ()
 #endif

--- a/test/TestLists.fs
+++ b/test/TestLists.fs
@@ -8,14 +8,14 @@ open Fable.Core.BeamInterop
 open Fable.Beam.Lists
 
 [<Emit("erlang:length($0)")>]
-let erlLength (xs: obj) : int = nativeOnly
+let erlLength (xs: BeamList<'T>) : int = nativeOnly
 #endif
 
 [<Fact>]
 let ``test lists.reverse works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[1, 2, 3]"
-    let expected: obj = emitErlExpr () "[3, 2, 1]"
+    let xs: BeamList<int> = emitErlExpr () "[1, 2, 3]"
+    let expected: BeamList<int> = emitErlExpr () "[3, 2, 1]"
     lists.reverse xs |> equal expected
 #else
     ()
@@ -24,9 +24,9 @@ let ``test lists.reverse works`` () =
 [<Fact>]
 let ``test lists.member works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[1, 2, 3]"
-    lists.``member`` (box 2, xs) |> equal true
-    lists.``member`` (box 4, xs) |> equal false
+    let xs: BeamList<int> = emitErlExpr () "[1, 2, 3]"
+    lists.``member`` (2, xs) |> equal true
+    lists.``member`` (4, xs) |> equal false
 #else
     ()
 #endif
@@ -34,8 +34,8 @@ let ``test lists.member works`` () =
 [<Fact>]
 let ``test lists.sort works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[3, 1, 2]"
-    let expected: obj = emitErlExpr () "[1, 2, 3]"
+    let xs: BeamList<int> = emitErlExpr () "[3, 1, 2]"
+    let expected: BeamList<int> = emitErlExpr () "[1, 2, 3]"
     lists.sort xs |> equal expected
 #else
     ()
@@ -44,9 +44,9 @@ let ``test lists.sort works`` () =
 [<Fact>]
 let ``test lists.append works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[1, 2]"
-    let ys: obj = emitErlExpr () "[3, 4]"
-    let expected: obj = emitErlExpr () "[1, 2, 3, 4]"
+    let xs: BeamList<int> = emitErlExpr () "[1, 2]"
+    let ys: BeamList<int> = emitErlExpr () "[3, 4]"
+    let expected: BeamList<int> = emitErlExpr () "[1, 2, 3, 4]"
     lists.append (xs, ys) |> equal expected
 #else
     ()
@@ -55,8 +55,8 @@ let ``test lists.append works`` () =
 [<Fact>]
 let ``test lists.last works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[1, 2, 3]"
-    lists.last xs |> equal (box 3)
+    let xs: BeamList<int> = emitErlExpr () "[1, 2, 3]"
+    lists.last xs |> equal 3
 #else
     ()
 #endif
@@ -65,8 +65,8 @@ let ``test lists.last works`` () =
 let ``test lists.nth works`` () =
 #if FABLE_COMPILER
     // Erlang lists:nth is 1-based
-    let xs: obj = emitErlExpr () "[10, 20, 30]"
-    lists.nth (1, xs) |> equal (box 10)
+    let xs: BeamList<int> = emitErlExpr () "[10, 20, 30]"
+    lists.nth (1, xs) |> equal 10
 #else
     ()
 #endif
@@ -74,8 +74,8 @@ let ``test lists.nth works`` () =
 [<Fact>]
 let ``test lists.flatten works`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[[1, 2], [3, 4]]"
-    let expected: obj = emitErlExpr () "[1, 2, 3, 4]"
+    let xs: BeamList<BeamList<int>> = emitErlExpr () "[[1, 2], [3, 4]]"
+    let expected: BeamList<int> = emitErlExpr () "[1, 2, 3, 4]"
     lists.flatten xs |> equal expected
 #else
     ()
@@ -84,8 +84,8 @@ let ``test lists.flatten works`` () =
 [<Fact>]
 let ``test lists.usort removes duplicates`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[3, 1, 2, 1, 3]"
-    let expected: obj = emitErlExpr () "[1, 2, 3]"
+    let xs: BeamList<int> = emitErlExpr () "[3, 1, 2, 1, 3]"
+    let expected: BeamList<int> = emitErlExpr () "[1, 2, 3]"
     lists.usort xs |> equal expected
 #else
     ()
@@ -94,7 +94,7 @@ let ``test lists.usort removes duplicates`` () =
 [<Fact>]
 let ``test lists.unzip returns tuple of two lists`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[{1, a}, {2, b}, {3, c}]"
+    let xs: BeamList<obj * obj> = emitErlExpr () "[{1, a}, {2, b}, {3, c}]"
     let (list1, list2) = lists.unzip xs
     erlLength list1 |> equal 3
     erlLength list2 |> equal 3
@@ -105,9 +105,8 @@ let ``test lists.unzip returns tuple of two lists`` () =
 [<Fact>]
 let ``test lists.partition returns tuple of two lists`` () =
 #if FABLE_COMPILER
-    let xs: obj = emitErlExpr () "[1, 2, 3, 4, 5]"
-    let pred: obj = emitErlExpr () "fun(X) -> X > 3 end"
-    let (matching, notMatching) = lists.partition (pred, xs)
+    let xs: BeamList<int> = emitErlExpr () "[1, 2, 3, 4, 5]"
+    let (matching, notMatching) = lists.partition (System.Func<_, _>(fun x -> x > 3), xs)
     erlLength matching |> equal 2
     erlLength notMatching |> equal 3
 #else

--- a/test/TestMaps.fs
+++ b/test/TestMaps.fs
@@ -9,7 +9,7 @@ open Fable.Beam.Maps
 [<Fact>]
 let ``test maps.new_ creates empty map`` () =
 #if FABLE_COMPILER
-    let m = maps.new_ ()
+    let m: BeamMap<string, int> = maps.new_ ()
     maps.size m |> equal 0
 #else
     ()
@@ -18,9 +18,9 @@ let ``test maps.new_ creates empty map`` () =
 [<Fact>]
 let ``test maps.put and get`` () =
 #if FABLE_COMPILER
-    let m = maps.new_ ()
-    let m = maps.put (box "key", box "value", m)
-    maps.get (box "key", m) |> equal (box "value")
+    let m: BeamMap<string, string> = maps.new_ ()
+    let m = maps.put ("key", "value", m)
+    maps.get ("key", m) |> equal "value"
 #else
     ()
 #endif
@@ -28,10 +28,10 @@ let ``test maps.put and get`` () =
 [<Fact>]
 let ``test maps.is_key works`` () =
 #if FABLE_COMPILER
-    let m = maps.new_ ()
-    let m = maps.put (box "a", box 1, m)
-    maps.is_key (box "a", m) |> equal true
-    maps.is_key (box "b", m) |> equal false
+    let m: BeamMap<string, int> = maps.new_ ()
+    let m = maps.put ("a", 1, m)
+    maps.is_key ("a", m) |> equal true
+    maps.is_key ("b", m) |> equal false
 #else
     ()
 #endif
@@ -39,9 +39,9 @@ let ``test maps.is_key works`` () =
 [<Fact>]
 let ``test maps.remove works`` () =
 #if FABLE_COMPILER
-    let m = maps.new_ ()
-    let m = maps.put (box "a", box 1, m)
-    let m = maps.remove (box "a", m)
+    let m: BeamMap<string, int> = maps.new_ ()
+    let m = maps.put ("a", 1, m)
+    let m = maps.remove ("a", m)
     maps.size m |> equal 0
 #else
     ()
@@ -50,9 +50,9 @@ let ``test maps.remove works`` () =
 [<Fact>]
 let ``test maps.size works`` () =
 #if FABLE_COMPILER
-    let m = maps.new_ ()
-    let m = maps.put (box "a", box 1, m)
-    let m = maps.put (box "b", box 2, m)
+    let m: BeamMap<string, int> = maps.new_ ()
+    let m = maps.put ("a", 1, m)
+    let m = maps.put ("b", 2, m)
     maps.size m |> equal 2
 #else
     ()
@@ -61,8 +61,8 @@ let ``test maps.size works`` () =
 [<Fact>]
 let ``test maps.merge works`` () =
 #if FABLE_COMPILER
-    let m1 = maps.put (box "a", box 1, maps.new_ ())
-    let m2 = maps.put (box "b", box 2, maps.new_ ())
+    let m1: BeamMap<string, int> = maps.put ("a", 1, maps.new_ ())
+    let m2 = maps.put ("b", 2, maps.new_ ())
     let merged = maps.merge (m1, m2)
     maps.size merged |> equal 2
 #else
@@ -70,15 +70,35 @@ let ``test maps.merge works`` () =
 #endif
 
 [<Fact>]
-let ``test maps.find returns tagged result`` () =
+let ``test maps.keys and values`` () =
 #if FABLE_COMPILER
-    let m = maps.put (box "key", box 42, maps.new_ ())
-    // maps.find returns {ok, Value} or the atom error
-    let result = maps.find (box "key", m)
-    let notFound = maps.find (box "missing", m)
-    // result should be {ok, 42}, notFound should be the atom error
-    Fable.Beam.Erlang.exactEquals notFound (box (Fable.Beam.Erlang.binaryToAtom "error")) |> equal true
-    Fable.Beam.Erlang.exactEquals result (box (Fable.Beam.Erlang.binaryToAtom "error")) |> equal false
+    let m: BeamMap<string, int> = maps.new_ ()
+    let m = maps.put ("a", 1, m)
+    let m = maps.put ("b", 2, m)
+    maps.keys m |> Array.length |> equal 2
+    maps.values m |> Array.length |> equal 2
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test maps.get with default`` () =
+#if FABLE_COMPILER
+    let m: BeamMap<string, int> = maps.new_ ()
+    maps.get ("missing", m, 42) |> equal 42
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test maps.to_list and from_list`` () =
+#if FABLE_COMPILER
+    let m: BeamMap<string, int> = maps.new_ ()
+    let m = maps.put ("a", 1, m)
+    let lst = maps.to_list m
+    Array.length lst |> equal 1
+    let m2 = maps.from_list lst
+    maps.size m2 |> equal 1
 #else
     ()
 #endif

--- a/test/test_counter_server.erl
+++ b/test/test_counter_server.erl
@@ -1,0 +1,21 @@
+-module(test_counter_server).
+-behaviour(gen_server).
+
+-export([init/1, handle_call/3, handle_cast/2]).
+
+init(InitialCount) ->
+    {ok, InitialCount}.
+
+handle_call(get, _From, State) ->
+    {reply, State, State};
+handle_call(increment, _From, State) ->
+    {reply, State + 1, State + 1};
+handle_call({add, N}, _From, State) ->
+    {reply, State + N, State + N};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast({set, N}, _State) ->
+    {noreply, N};
+handle_cast(_Request, State) ->
+    {noreply, State}.


### PR DESCRIPTION
## Summary

- Introduce `BeamMap<'K,'V>` and `BeamList<'T>` generic erased single-case unions for compile-time type safety with zero runtime cost
- Replace `obj` with concrete types across Maps, Lists, Ets, GenServer, and Timer bindings
- Use `[<Emit>]` on abstract members to override `ImportAll` codegen for `fable_utils:new_ref()` wrapping (fixes `Array.length` on Erlang list returns)
- Use `System.Func<>`/`System.Action<>` for typed callbacks instead of `obj`
- Add `U2<int, Atom>` for timeout parameters, `Result<Pid, obj>` / `Result<TimerRef, Atom>` for return types
- Add `ServerRef` erased type for gen_server references
- Add `test_counter_server.erl` callback module and 7 new gen_server tests (93 total, all passing)
- Update BINDINGS-GUIDE.md with all new patterns

## Test plan

- [x] All 93 tests pass (`just test`) — full F# → Erlang → BEAM pipeline
- [x] New gen_server tests cover start_link, start, call, call with timeout, cast, stop, stop with reason
- [x] ETS tests use `Array.length` instead of `erlLength` workaround
- [x] Maps tests use typed `BeamMap<string, int>` with no `box` calls
- [x] Lists tests use typed `BeamList<int>` with no `box` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)