### PR TITLE
feat: add Fable.Beam.Jsx bindings for jsx JSON library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,12 @@ jobs:
           dotnet pack src/cowboy -c Release -p:PackageVersion=${{ steps.release.outputs.version }} -p:InformationalVersion=${{ steps.release.outputs.version }}
           dotnet nuget push 'src/cowboy/bin/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
 
+      - name: Pack and push Fable.Beam.Jsx
+        if: steps.release.outputs.package == 'Fable.Beam.Jsx'
+        run: |
+          dotnet pack src/jsx -c Release -p:PackageVersion=${{ steps.release.outputs.version }} -p:InformationalVersion=${{ steps.release.outputs.version }}
+          dotnet nuget push 'src/jsx/bin/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+
       - name: Create GitHub Release
         run: gh release create "${{ steps.release.outputs.tag }}" --title "${{ steps.release.outputs.tag }}" --generate-notes || echo "Release already exists"
         env:

--- a/README.md
+++ b/README.md
@@ -8,13 +8,22 @@ BEAM backend. This package provides typed bindings for
 Erlang/OTP standard modules so you can call them directly
 from F#.
 
-## Available Modules
+## Packages
+
+| Package | Description |
+| --- | --- |
+| `Fable.Beam` | Core Erlang/OTP bindings |
+| `Fable.Beam.Cowboy` | Cowboy HTTP server bindings |
+| `Fable.Beam.Jsx` | jsx JSON library bindings |
+
+### Fable.Beam — OTP Modules
 
 | Module | Binding | Description |
 | --- | --- | --- |
 | `Fable.Beam.Erlang` | `erlang` | BIFs: processes, send/receive, monitors |
 | `Fable.Beam.GenServer` | `gen_server` | Generic server behaviour |
 | `Fable.Beam.Supervisor` | `supervisor` | Supervisor behaviour |
+| `Fable.Beam.Application` | `application` | OTP application management |
 | `Fable.Beam.Timer` | `timer` | Timer functions, sleep, conversions |
 | `Fable.Beam.Ets` | `ets` | Erlang Term Storage |
 | `Fable.Beam.Maps` | `maps` | Erlang map operations |
@@ -22,14 +31,35 @@ from F#.
 | `Fable.Beam.Io` | `io` | I/O functions |
 | `Fable.Beam.Logger` | `logger` | OTP logger |
 | `Fable.Beam.File` | `file` | File system operations |
+| `Fable.Beam.Os` | `os` | OS interaction, env vars, system time |
+| `Fable.Beam.Httpc` | `httpc` | HTTP client (inets) |
+| `Fable.Beam.Init` | `init` | Runtime system control |
 | `Fable.Beam.Testing` | - | Test helpers (Fact, assertions) |
+
+### Fable.Beam.Cowboy
+
+| Module | Binding | Description |
+| --- | --- | --- |
+| `Fable.Beam.Cowboy.Cowboy` | `cowboy` | Listener start/stop |
+| `Fable.Beam.Cowboy.CowboyReq` | `cowboy_req` | Request/response handling |
+| `Fable.Beam.Cowboy.CowboyRouter` | `cowboy_router` | Route compilation |
+| `Fable.Beam.Cowboy.CowboyHandler` | `cowboy_handler` | Handler callbacks |
+| `Fable.Beam.Cowboy.CowboyWebsocket` | `cowboy_websocket` | WebSocket support |
+
+### Fable.Beam.Jsx
+
+| Module | Binding | Description |
+| --- | --- | --- |
+| `Fable.Beam.Jsx.Jsx` | `jsx` | JSON encode, decode, format, validate |
 
 ## Usage
 
-Add the NuGet package to your project:
+Add the NuGet packages to your project:
 
 ```text
 paket add Fable.Beam
+paket add Fable.Beam.Cowboy   # optional: HTTP server
+paket add Fable.Beam.Jsx      # optional: JSON
 ```
 
 Then use the bindings in your F# code:
@@ -61,10 +91,10 @@ match Erlang.receive<Msg> 5000 with
 | Some Stop -> exit (box "normal")
 | None -> printfn "Timeout"
 
-// Erlang maps
-let m = maps.new_ ()
-let m = maps.put (box "key", box "value", m)
-let v = maps.get (box "key", m)
+// Typed Erlang maps (generic — no box needed)
+let m: BeamMap<string, int> = maps.new_ ()
+let m = maps.put ("key", 42, m)
+let v = maps.get ("key", m)  // returns int
 
 // Timers
 timer.sleep 100
@@ -77,6 +107,16 @@ demonitorFlush monRef
 // Process dictionary
 put (box "my_key") (box 42) |> ignore
 let value = get (box "my_key")
+```
+
+### JSON with jsx
+
+```fsharp
+open Fable.Beam.Jsx.Jsx
+
+let json = jsx.encode {| name = "world" |}
+let valid = jsx.is_json (json, [strict])
+let mini = jsx.minify """{ "key" : "value" }"""
 ```
 
 ## Prerequisites
@@ -128,24 +168,20 @@ just pack
 
 ```text
 src/
-  otp/
-    Erlang.fs        # Erlang BIFs (Emit-based bindings)
-    GenServer.fs     # gen_server module (ImportAll binding)
-    Supervisor.fs    # supervisor module
-    Timer.fs         # timer module
-    Ets.fs           # ets module
-    Maps.fs          # maps module
-    Lists.fs         # lists module
-    Io.fs            # io module
-    Logger.fs        # logger module
-    File.fs          # file module
-    Testing.fs       # Test utilities
+  otp/             # Fable.Beam — OTP stdlib bindings
+    Erlang.fs, GenServer.fs, Supervisor.fs, Timer.fs,
+    Ets.fs, Maps.fs, Lists.fs, Io.fs, Logger.fs,
+    File.fs, Os.fs, Httpc.fs, Application.fs, Init.fs,
+    Testing.fs
+  cowboy/          # Fable.Beam.Cowboy — HTTP server bindings
+    Cowboy.fs, CowboyReq.fs, CowboyRouter.fs,
+    CowboyHandler.fs, CowboyWebsocket.fs
+  jsx/             # Fable.Beam.Jsx — JSON library bindings
+    Jsx.fs
 test/
-  TestErlang.fs      # Erlang BIF tests
-  TestEts.fs         # ETS tests
-  TestMaps.fs        # Maps tests
-  ...
+  Test*.fs           # Test files
   test_runner.erl    # BEAM test runner
+  rebar.config       # Erlang test dependencies
 ```
 
 ## Binding Patterns
@@ -157,10 +193,10 @@ The bindings use two Fable interop patterns:
 
 ```fsharp
 [<Emit("erlang:self()")>]
-let self () : obj = nativeOnly
+let self () : Pid = nativeOnly
 
 [<Emit("$0 ! $1")>]
-let send (pid: obj) (msg: obj) : unit = nativeOnly
+let send (pid: Pid) (msg: obj) : unit = nativeOnly
 ```
 
 **`[<Erase>]` + `[<ImportAll>]`** for Erlang module
@@ -179,30 +215,13 @@ let timer: IExports = nativeOnly
 ## Interop Notes
 
 **Erlang lists vs F# arrays:** Fable on BEAM represents
-F# arrays as ref-wrapped values in the process dictionary.
-Raw Erlang lists returned from OTP calls (e.g.,
-`ets:tab2list/1`, `maps:keys/1`) are *not* ref-wrapped,
-so F# `.Length` will not work on them. Use
-`Erlang.length` instead:
-
-```fsharp
-open Fable.Beam.Erlang
-open Fable.Beam.Ets
-
-let table =
-    ets.new_ (
-        binaryToAtom "my_table",
-        [ box (binaryToAtom "set") ]
-    )
-let all = ets.tab2list table
-
-// Don't use: all.Length (will fail at runtime)
-// Use instead:
-let count = Erlang.length (box all)
-```
-
-Similarly, use `Erlang.element` and `Erlang.tupleSize`
-for raw Erlang tuples, and `Erlang.byteSize` for binaries.
+F# arrays as ref-wrapped values (via `fable_utils:new_ref`).
+Raw Erlang lists returned from some OTP calls (e.g.,
+`ets:tab2list/1`) are *not* ref-wrapped, so F#
+`Array.length` will not work on them directly. Bindings
+that return F# arrays (e.g., `maps.keys`, `maps.to_list`)
+wrap the result automatically so standard array operations
+work.
 
 **Atoms from strings:** Fable compiles F# strings to
 Erlang binaries (`<<"hello">>`), not charlists. Use

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ build-beam:
     dotnet build {{test_path}}
     {{fable}} {{test_path}} --lang Erlang --outDir {{build_path}}/tests
     cp {{test_path}}/test_runner.erl {{test_path}}/test_counter_server.erl {{build_path}}/tests/src/
+    cp {{test_path}}/rebar.config {{build_path}}/tests/rebar.config
     cd {{build_path}}/tests && rebar3 compile
 
 # Run BEAM tests (transpile F# to Erlang, compile, run on BEAM)
@@ -46,6 +47,7 @@ test: build-beam
     cd {{build_path}}/tests && erl -noshell \
         -pa _build/default/lib/fable_beam_test/ebin \
         -pa _build/default/lib/fable_library_beam/ebin \
+        -pa _build/default/lib/jsx/ebin \
         -eval 'test_runner:main(["_build/default/lib/fable_beam_test/ebin"])' \
         -s init stop
 
@@ -59,11 +61,13 @@ pack:
     dotnet build {{src_path}}
     dotnet pack {{src_path}} -c Release
     dotnet pack {{src_path}}/cowboy -c Release
+    dotnet pack {{src_path}}/jsx -c Release
 
 # Create NuGet packages with specific version (used in CI)
 pack-version version:
     dotnet pack {{src_path}} -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
     dotnet pack {{src_path}}/cowboy -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
+    dotnet pack {{src_path}}/jsx -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
 
 # Format code with Fantomas
 format:

--- a/src/jsx/CHANGELOG.md
+++ b/src/jsx/CHANGELOG.md
@@ -1,0 +1,7 @@
+---
+name: Fable.Beam.Jsx
+---
+
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/src/jsx/Fable.Beam.Jsx.fsproj
+++ b/src/jsx/Fable.Beam.Jsx.fsproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Author>Dag Brattli</Author>
+    <Copyright>Dag Brattli</Copyright>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+    <PackageTags>fsharp;fable;fable-binding;fable-beam;erlang;jsx;json</PackageTags>
+    <Description>Fable bindings for jsx JSON library on BEAM</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Jsx.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/src/jsx/Jsx.fs
+++ b/src/jsx/Jsx.fs
@@ -1,0 +1,78 @@
+/// Fable bindings for the jsx JSON library.
+/// See: https://github.com/talentdeficit/jsx
+module Fable.Beam.Jsx.Jsx
+
+open Fable.Core
+
+// fsharplint:disable MemberNames
+
+// ============================================================================
+// Options
+// ============================================================================
+
+/// Opaque jsx option passed to decode, encode, format, is_json, and is_term.
+[<Erase>]
+type JsxOpt = JsxOpt of obj
+
+/// Return maps instead of proplists for JSON objects (default since jsx 3.0).
+[<Emit("return_maps")>]
+let returnMaps: JsxOpt = nativeOnly
+
+/// Enable strict JSON parsing (no comments, no trailing commas).
+[<Emit("strict")>]
+let strict: JsxOpt = nativeOnly
+
+/// Enable streaming mode for incremental parsing.
+[<Emit("stream")>]
+let stream: JsxOpt = nativeOnly
+
+/// Escape unicode characters to \\uXXXX sequences.
+[<Emit("uescape")>]
+let uescape: JsxOpt = nativeOnly
+
+/// Set label handling for JSON object keys (e.g., binary_to_atom).
+[<Emit("{labels, $0}")>]
+let labels (mode: obj) : JsxOpt = nativeOnly
+
+/// Set the number of spaces for indentation when formatting.
+[<Emit("{indent, $0}")>]
+let indent (n: int) : JsxOpt = nativeOnly
+
+/// Set the number of spaces after colon/comma when formatting.
+[<Emit("{space, $0}")>]
+let space (n: int) : JsxOpt = nativeOnly
+
+// ============================================================================
+// Module binding
+// ============================================================================
+
+[<Erase>]
+type IExports =
+    /// Decode a UTF-8 JSON binary into Erlang terms.
+    abstract decode: json: string -> 'T
+    /// Decode a UTF-8 JSON binary into Erlang terms with options.
+    abstract decode: json: string * opts: JsxOpt list -> 'T
+    /// Encode an Erlang term into a UTF-8 JSON binary.
+    abstract encode: term: 'T -> string
+    /// Encode an Erlang term into a UTF-8 JSON binary with options.
+    abstract encode: term: 'T * opts: JsxOpt list -> string
+    /// Format a JSON binary.
+    abstract format: json: string -> string
+    /// Format a JSON binary with options.
+    abstract format: json: string * opts: JsxOpt list -> string
+    /// Minify a JSON binary (remove whitespace).
+    abstract minify: json: string -> string
+    /// Prettify a JSON binary (add readable formatting).
+    abstract prettify: json: string -> string
+    /// Check if a binary is valid JSON.
+    abstract is_json: json: string -> bool
+    /// Check if a binary is valid JSON with options.
+    abstract is_json: json: string * opts: JsxOpt list -> bool
+    /// Check if an Erlang term is a valid JSON-representable term.
+    abstract is_term: term: 'T -> bool
+    /// Check if an Erlang term is a valid JSON-representable term with options.
+    abstract is_term: term: 'T * opts: JsxOpt list -> bool
+
+/// jsx module
+[<ImportAll("jsx")>]
+let jsx: IExports = nativeOnly

--- a/src/jsx/paket.references
+++ b/src/jsx/paket.references
@@ -1,0 +1,2 @@
+FSharp.Core
+Fable.Core

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Fable.Beam.fsproj" />
+    <ProjectReference Include="../src/jsx/Fable.Beam.Jsx.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TestErlang.fs" />
@@ -25,6 +26,7 @@
     <Compile Include="TestOs.fs" />
     <Compile Include="TestFile.fs" />
     <Compile Include="TestLogger.fs" />
+    <Compile Include="TestJsx.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/test/TestJsx.fs
+++ b/test/TestJsx.fs
@@ -1,0 +1,88 @@
+module Fable.Beam.Tests.Jsx
+
+open Fable.Beam.Testing
+
+#if FABLE_COMPILER
+open Fable.Beam.Jsx.Jsx
+#endif
+
+[<Fact>]
+let ``test jsx encode integer`` () =
+#if FABLE_COMPILER
+    let json = jsx.encode 42
+    json |> equal "42"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx encode string`` () =
+#if FABLE_COMPILER
+    let json = jsx.encode "hello"
+    json |> equal "\"hello\""
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx decode string`` () =
+#if FABLE_COMPILER
+    let result: string = jsx.decode "\"hello\""
+    result |> equal "hello"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx is_json valid`` () =
+#if FABLE_COMPILER
+    jsx.is_json """{"key": "value"}""" |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx is_json invalid`` () =
+#if FABLE_COMPILER
+    jsx.is_json "not json" |> equal false
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx minify`` () =
+#if FABLE_COMPILER
+    let result = jsx.minify """{ "key" : "value" }"""
+    result |> equal """{"key":"value"}"""
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx prettify and minify roundtrip`` () =
+#if FABLE_COMPILER
+    let json = """{"key":"value"}"""
+    let pretty = jsx.prettify json
+    let mini = jsx.minify pretty
+    mini |> equal json
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx is_json with strict rejects trailing comma`` () =
+#if FABLE_COMPILER
+    jsx.is_json ("""{"key": "value",}""", [ strict ]) |> equal false
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx format with indent`` () =
+#if FABLE_COMPILER
+    let result = jsx.format ("""{"key":"value"}""", [ indent 2 ])
+    // Formatted output should be longer than minified
+    (String.length result > String.length """{"key":"value"}""") |> equal true
+#else
+    ()
+#endif

--- a/test/rebar.config
+++ b/test/rebar.config
@@ -1,0 +1,7 @@
+{erl_opts, [debug_info]}.
+
+{project_app_dirs, [".", "fable_modules/*"]}.
+
+{deps, [
+    {jsx, "3.1.0"}
+]}.


### PR DESCRIPTION
## Summary
- Add new `Fable.Beam.Jsx` NuGet package with typed F# bindings for the [jsx](https://github.com/talentdeficit/jsx) Erlang JSON library
- Bindings use `ImportAll` pattern with overloads for all multi-arity functions (`decode`, `encode`, `format`, `is_json`, `is_term`)
- Typed `JsxOpt` erased union for options (`strict`, `indent`, `space`, `uescape`, etc.) instead of `obj list`
- Generic type parameters on `encode`, `decode`, and `is_term` to avoid `obj`
- Add `test/rebar.config` to manage Erlang test dependencies (replaces patching the Fable-generated config)
- 9 tests covering encode, decode, is_json, minify, prettify, and options (strict, indent)

## Test plan
- [x] All 102 tests pass (`just test`)
- [ ] Verify `dotnet pack src/jsx` produces a valid NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)