### PR TITLE
fix: handle monorepo multi-project releases

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -39,52 +39,22 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore: release ')"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
+      - name: Install just
+        uses: extractions/setup-just@v3
+
       - name: Install tools
         run: |
           dotnet tool restore
           dotnet restore src
 
-      - name: Extract package and version
-        id: release
-        run: |
-          MESSAGE="${{ github.event.head_commit.message }}"
-          # Extract "Fable.Beam@1.0.0-rc.7" or "Fable.Beam.Cowboy@1.0.0-rc.7"
-          PACKAGE_VERSION="${MESSAGE#chore: release }"
-          PACKAGE_VERSION="${PACKAGE_VERSION%% *}"
-          PACKAGE="${PACKAGE_VERSION%%@*}"
-          VERSION="${PACKAGE_VERSION##*@}"
-          echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=${PACKAGE}@${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Pack and push Fable.Beam
-        if: steps.release.outputs.package == 'Fable.Beam'
-        run: |
-          dotnet pack src -c Release -p:PackageVersion=${{ steps.release.outputs.version }} -p:InformationalVersion=${{ steps.release.outputs.version }}
-          dotnet nuget push 'src/bin/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
-
-      - name: Pack and push Fable.Beam.Cowboy
-        if: steps.release.outputs.package == 'Fable.Beam.Cowboy'
-        run: |
-          dotnet pack src/cowboy -c Release -p:PackageVersion=${{ steps.release.outputs.version }} -p:InformationalVersion=${{ steps.release.outputs.version }}
-          dotnet nuget push 'src/cowboy/bin/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
-
-      - name: Pack and push Fable.Beam.Jsx
-        if: steps.release.outputs.package == 'Fable.Beam.Jsx'
-        run: |
-          dotnet pack src/jsx -c Release -p:PackageVersion=${{ steps.release.outputs.version }} -p:InformationalVersion=${{ steps.release.outputs.version }}
-          dotnet nuget push 'src/jsx/bin/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
-
-      - name: Create GitHub Release
-        run: gh release create "${{ steps.release.outputs.tag }}" --title "${{ steps.release.outputs.tag }}" --generate-notes || echo "Release already exists"
+      - name: Build, pack and push
+        run: just release
         env:
-          GH_TOKEN: ${{ github.token }}
+          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/justfile
+++ b/justfile
@@ -69,6 +69,19 @@ pack-version version:
     dotnet pack {{src_path}}/cowboy -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
     dotnet pack {{src_path}}/jsx -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
 
+# Pack all packages with versions from changelogs and push to NuGet (used in CI)
+release:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    get_version() { grep -m1 '^## ' "$1" | sed 's/^## \([^ ]*\).*/\1/'; }
+    BEAM_VERSION=$(get_version src/otp/CHANGELOG.md)
+    COWBOY_VERSION=$(get_version src/cowboy/CHANGELOG.md)
+    JSX_VERSION=$(get_version src/jsx/CHANGELOG.md)
+    dotnet pack src -c Release -o ./nupkgs -p:PackageVersion=$BEAM_VERSION -p:InformationalVersion=$BEAM_VERSION
+    dotnet pack src/cowboy -c Release -o ./nupkgs -p:PackageVersion=$COWBOY_VERSION -p:InformationalVersion=$COWBOY_VERSION
+    dotnet pack src/jsx -c Release -o ./nupkgs -p:PackageVersion=$JSX_VERSION -p:InformationalVersion=$JSX_VERSION
+    dotnet nuget push './nupkgs/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_KEY
+
 # Format code with Fantomas
 format:
     dotnet fantomas {{src_path}} -r

--- a/justfile
+++ b/justfile
@@ -56,21 +56,8 @@ test-dotnet:
     dotnet build {{test_path}}
     dotnet run --project {{test_path}}
 
-# Create NuGet packages
+# Create NuGet packages with versions from changelogs
 pack:
-    dotnet build {{src_path}}
-    dotnet pack {{src_path}} -c Release
-    dotnet pack {{src_path}}/cowboy -c Release
-    dotnet pack {{src_path}}/jsx -c Release
-
-# Create NuGet packages with specific version (used in CI)
-pack-version version:
-    dotnet pack {{src_path}} -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
-    dotnet pack {{src_path}}/cowboy -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
-    dotnet pack {{src_path}}/jsx -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
-
-# Pack all packages with versions from changelogs and push to NuGet (used in CI)
-release:
     #!/usr/bin/env bash
     set -euo pipefail
     get_version() { grep -m1 '^## ' "$1" | sed 's/^## \([^ ]*\).*/\1/'; }
@@ -80,6 +67,9 @@ release:
     dotnet pack src -c Release -o ./nupkgs -p:PackageVersion=$BEAM_VERSION -p:InformationalVersion=$BEAM_VERSION
     dotnet pack src/cowboy -c Release -o ./nupkgs -p:PackageVersion=$COWBOY_VERSION -p:InformationalVersion=$COWBOY_VERSION
     dotnet pack src/jsx -c Release -o ./nupkgs -p:PackageVersion=$JSX_VERSION -p:InformationalVersion=$JSX_VERSION
+
+# Pack and push all packages to NuGet (used in CI)
+release: pack
     dotnet nuget push './nupkgs/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_KEY
 
 # Format code with Fantomas


### PR DESCRIPTION
## Summary
- Fix publish workflow skipping all packages on `chore: release multiple projects` commits
- Add `just release` recipe that reads versions from each `CHANGELOG.md` and packs/pushes all packages
- Simplify workflow to match [ShipIt recommended pattern](https://github.com/easybuild-org/EasyBuild.ShipIt#github-actions-auto-release) — release job just calls `just release`
- Bump `actions/checkout` to v6

## Test plan
- [ ] Merge and verify the next ShipIt release commit triggers successful NuGet publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)