### PR TITLE
feat: add set_primary_config and add_primary_filter bindings to Logger

### DIFF
--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -3,6 +3,7 @@
 module Fable.Beam.Logger
 
 open Fable.Core
+open Fable.Beam.Erlang
 
 // fsharplint:disable MemberNames
 
@@ -40,6 +41,11 @@ type IExports =
     abstract debug: msg: string -> unit
     /// Log a debug message with metadata or format args.
     abstract debug: msg: string * metadataOrArgs: obj -> unit
+    /// Set the primary logger configuration. Common use: set_primary_config("level", atom)
+    abstract set_primary_config: key: string * value: Atom -> unit
+    /// Add a primary filter. Filters run before handler filters and can stop or modify events.
+    /// The filter is a tuple {FilterFun, Extra} where FilterFun is fun(LogEvent, Extra) -> stop | ignore | LogEvent.
+    abstract add_primary_filter: id: Atom * filter: (System.Func<obj, obj, obj> * obj) -> unit
 
 /// logger module
 [<ImportAll("logger")>]


### PR DESCRIPTION
## Summary
- Add `set_primary_config` binding to set the primary logger configuration (e.g. log level)
- Add `add_primary_filter` binding to add primary filters that can suppress noisy OTP reports
- Filter is typed as `(System.Func<obj, obj, obj> * obj)` matching Erlang's `{FilterFun, Extra}` tuple

## Test plan
- [ ] `just test-dotnet` — verify F# compilation
- [ ] `just test` — verify Erlang transpilation and BEAM execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)