### PR TITLE
fix: skip ShipIt PR creation on release commits to prevent loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   shipit-pr:
     name: ShipIt - Pull Request
     runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore: release ')"
     timeout-minutes: 10
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `if: "!startsWith(github.event.head_commit.message, 'chore: release ')"` to the `shipit-pr` job
- Prevents the infinite loop where merging a release PR triggers another release PR (rc.18 → rc.19 → rc.20 → ...)

## Test plan
- [ ] Merge this PR and verify no new release PR is created from the merge commit
- [ ] Push an actual feature commit and verify ShipIt still creates a release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)