### PR TITLE
fix: use Atom type for set_primary_config key parameter

### DIFF
--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -41,8 +41,8 @@ type IExports =
     abstract debug: msg: string -> unit
     /// Log a debug message with metadata or format args.
     abstract debug: msg: string * metadataOrArgs: obj -> unit
-    /// Set the primary logger configuration. Common use: set_primary_config("level", atom)
-    abstract set_primary_config: key: string * value: Atom -> unit
+    /// Set the primary logger configuration. Common use: set_primary_config(atom "level", atom "debug")
+    abstract set_primary_config: key: Atom * value: Atom -> unit
     /// Add a primary filter. Filters run before handler filters and can stop or modify events.
     /// The filter is a tuple {FilterFun, Extra} where FilterFun is fun(LogEvent, Extra) -> stop | ignore | LogEvent.
     abstract add_primary_filter: id: Atom * filter: (System.Func<obj, obj, obj> * obj) -> unit


### PR DESCRIPTION
## Summary
- Changes `set_primary_config` key parameter from `string` to `Atom` in Logger bindings
- Erlang's `logger:set_primary_config/2` expects atoms for both arguments — a string compiles to a binary (`<<"level">>`) which Erlang silently ignores

## Test plan
- [ ] Verify `Logger.set_primary_config(atom "level", atom "debug")` correctly sets the log level on BEAM

🤖 Generated with [Claude Code](https://claude.com/claude-code)