### PR TITLE
feat: add Logger handler config, simplify filter, and add phash2 binding

### DIFF
--- a/src/otp/Erlang.fs
+++ b/src/otp/Erlang.fs
@@ -123,6 +123,10 @@ let systemTime (unit: Atom) : int = nativeOnly
 [<Emit("erlang:system_time(second)")>]
 let systemTimeSec () : int = nativeOnly
 
+/// Hash a term to a value in [0, Range). Useful for partitioning or load balancing.
+[<Emit("erlang:phash2($0, $1)")>]
+let phash2 (term: obj) (range: int) : int = nativeOnly
+
 /// Schedule a message to be sent to self after Ms milliseconds.
 [<Emit("erlang:send_after($0, erlang:self(), $1)")>]
 let sendAfter (ms: int) (msg: obj) : TimerRef = nativeOnly

--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -43,9 +43,10 @@ type IExports =
     abstract debug: msg: string * metadataOrArgs: obj -> unit
     /// Set the primary logger configuration. Common use: set_primary_config(atom "level", atom "debug")
     abstract set_primary_config: key: Atom * value: Atom -> unit
-    /// Add a primary filter. Filters run before handler filters and can stop or modify events.
-    /// The filter is a tuple {FilterFun, Extra} where FilterFun is fun(LogEvent, Extra) -> stop | ignore | LogEvent.
-    abstract add_primary_filter: id: Atom * filter: (System.Func<obj, obj, obj> * obj) -> unit
+    /// Update a handler's configuration. Common use: change formatter template.
+    abstract update_handler_config: handler: Atom * key: Atom * value: obj -> unit
+    /// Add a primary filter. The filter is an opaque {FilterFun, Extra} tuple.
+    abstract add_primary_filter: id: Atom * filter: obj -> unit
 
 /// logger module
 [<ImportAll("logger")>]


### PR DESCRIPTION
## Summary
- Add `update_handler_config` binding for `logger:update_handler_config/3` — used to change handler settings like formatter templates
- Simplify `add_primary_filter` filter parameter from `(System.Func<obj, obj, obj> * obj)` to `obj` — Erlang logger filters are `{fun/2, term()}` tuples typically constructed via `[<Emit>]`
- Add `phash2` binding for `erlang:phash2/2` — hash a term to a value in `[0, Range)`, useful for partitioning or load balancing

## Test plan
- [ ] Verify `Logger.update_handler_config(atom "default", atom "formatter", formatterConfig)` works on BEAM
- [ ] Verify `Logger.add_primary_filter(atom "my_filter", filterTuple)` works with Emit-constructed filters
- [ ] Verify `phash2 someValue 1000000` returns a consistent hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)