### PR TITLE
chore: bump Fable.Core to 5.0.0-rc.2 and refresh test deps

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core 5.0.0-rc.1
+nuget Fable.Core 5.0.0-rc.2
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -13,7 +13,7 @@ group Test
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.1
+    nuget Fable.Core 5.0.0-rc.2
     nuget Microsoft.NET.Test.Sdk ~> 16
     nuget xunit ~> 2
     nuget xunit.runner.visualstudio ~> 2

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0.0-rc.2)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -11,20 +11,20 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0.0-rc.2)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
-    Microsoft.CodeCoverage (18.3)
+    Microsoft.CodeCoverage (18.4)
     Microsoft.NET.Test.Sdk (16.11)
       Microsoft.CodeCoverage (>= 16.11)
       Microsoft.TestPlatform.TestHost (>= 16.11)
-    Microsoft.TestPlatform.ObjectModel (18.3)
+    Microsoft.TestPlatform.ObjectModel (18.4)
       System.Reflection.Metadata (>= 8.0)
-    Microsoft.TestPlatform.TestHost (18.3)
-      Microsoft.TestPlatform.ObjectModel (>= 18.3)
+    Microsoft.TestPlatform.TestHost (18.4)
+      Microsoft.TestPlatform.ObjectModel (>= 18.4)
       Newtonsoft.Json (>= 13.0.3)
     Newtonsoft.Json (13.0.4)
-    System.Reflection.Metadata (10.0.5)
+    System.Reflection.Metadata (10.0.6)
     xunit (2.9.3)
       xunit.analyzers (>= 1.18)
       xunit.assert (>= 2.9.3)


### PR DESCRIPTION
## Summary

- Main group: `Fable.Core` 5.0.0-rc.1 → 5.0.0-rc.2
- Test group: same `Fable.Core` bump, plus refreshes of `Microsoft.CodeCoverage`, `Microsoft.TestPlatform.ObjectModel`, `Microsoft.TestPlatform.TestHost` (18.3 → 18.4), and `System.Reflection.Metadata` (10.0.5 → 10.0.6)

Result of running `dotnet paket update` on `main`.

## Test plan

- [ ] CI `build` green
- [ ] CI `lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)