### PR TITLE
fix: skip duplicate packages on release push

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ pack:
 
 # Pack and push all packages to NuGet (used in CI)
 release: pack
-    dotnet nuget push './nupkgs/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_KEY
+    dotnet nuget push './nupkgs/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_KEY --skip-duplicate
 
 # Format code with Fantomas
 format:


### PR DESCRIPTION
## Summary

The release workflow just failed (run [24525339328](https://github.com/fable-compiler/Fable.Beam/actions/runs/24525339328/job/71693932552)) with a 409 on `Fable.Beam.Cowboy.5.0.0-rc.22` — that version was already published, so NuGet rejects the re-upload and `dotnet nuget push` exits 1.

`just release` packs all three packages from their individual `CHANGELOG.md` files on every merge to `main`. When only one changelog got a version bump, the other two packages collide with their already-published copies. Adding `--skip-duplicate` lets NuGet quietly ignore existing versions and proceed with the newly bumped one.

## Test plan

- [ ] Next release after merge publishes only the bumped package(s) and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)