### PR TITLE
build: relax Fable.Core constraint to >= 5.0.0-rc.1

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core 5.0.0-rc.2
+nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -13,7 +13,7 @@ group Test
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.2
+    nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
     nuget Microsoft.NET.Test.Sdk ~> 16
     nuget xunit ~> 2
     nuget xunit.runner.visualstudio ~> 2

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.2)
+    Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -11,7 +11,7 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.2)
+    Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
     Microsoft.CodeCoverage (18.4)


### PR DESCRIPTION
## Summary
- Change the `Fable.Core` constraint in `paket.dependencies` from the exact pin `5.0.0-rc.2` to `>= 5.0.0-rc.1 lowest_matching: true` (both Main and Test groups).
- Paket's exact pin gets packed into the produced nupkg as `[5.0.0-rc.2]`, which forces consumers on newer Fable.Core RCs into a NuGet resolver conflict. Switching to a minimum-version constraint matches how `Fable.Browser.*`, `Fable.Promise`, and `Fable.Solid` express their `Fable.Core` dependency.
- Floor set at `rc.1` (not `rc.2`) after confirming the bindings don't use any rc.2-specific API — `rc.2` landed as a pure dep bump (commit b2afe21).
- Mirrors the Paket-equivalent change in Fable.Python PR #257.

### Before / after

```diff
-nuget Fable.Core 5.0.0-rc.2
+nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
```

`paket.lock` re-resolved via `dotnet paket update`; Fable.Core now pins to `5.0.0-rc.1` under `lowest_matching`.

## Test plan
- [x] `just build` succeeds at the rc.1 floor
- [x] `just test` — 159/159 tests pass on BEAM at the rc.1 floor
- [x] `paket.lock` regenerated; Fable.Core resolves to `5.0.0-rc.1`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)