### PR TITLE
chore: upgrade Fable and Fable.Core to 5.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fable": {
-      "version": "5.0.0-rc.7",
+      "version": "5.0.0",
       "commands": [
         "fable"
       ],

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
+nuget Fable.Core >= 5.0.0 lowest_matching: true
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -13,7 +13,7 @@ group Test
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
+    nuget Fable.Core >= 5.0.0 lowest_matching: true
     nuget Microsoft.NET.Test.Sdk ~> 17
     nuget xunit ~> 2
     nuget xunit.runner.visualstudio ~> 2

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -11,7 +11,7 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
     Microsoft.CodeCoverage (18.4)
@@ -24,7 +24,7 @@ NUGET
       Microsoft.TestPlatform.ObjectModel (>= 18.4)
       Newtonsoft.Json (>= 13.0.3)
     Newtonsoft.Json (13.0.4)
-    System.Reflection.Metadata (10.0.6)
+    System.Reflection.Metadata (10.0.7)
     xunit (2.9.3)
       xunit.analyzers (>= 1.18)
       xunit.assert (>= 2.9.3)


### PR DESCRIPTION
## Summary
- Bump Fable CLI from `5.0.0-rc.7` to `5.0.0` in `.config/dotnet-tools.json`
- Raise Fable.Core floor from `>= 5.0.0-rc.1` to `>= 5.0.0` in both paket groups
- Keep `lowest_matching: true` so consumers can still float forward
- `paket.lock` regenerated

## Test plan
- [x] `just test-dotnet` — F# compiles clean
- [x] `just test` — full BEAM pipeline, 237/237 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)