### PR TITLE
feat: tighten typing with phantom params, Dynamic, and decoders

### DIFF
--- a/BINDINGS-GUIDE.md
+++ b/BINDINGS-GUIDE.md
@@ -11,10 +11,14 @@ its corresponding Erlang doc page in a top-level `///` comment (e.g.,
 
 When writing or reviewing a binding, check:
 
+- **No bare `obj`** — see "Core Rule: Avoid `obj`" below. Use generics, phantom types, DUs, records, or `Dynamic` instead.
+- **Phantom type parameters** on opaque handles (`Pid<'Msg>`, `Ref<'Tag>`, `TableId<'K, 'R>`)
 - **Parameter types** — match the Erlang typespec (e.g., if the doc says `atom()`, use `Atom` not `obj`)
-- **Return types** — match the Erlang typespec (e.g., `{ok, pid()}` → `Result<Pid, string>`)
+- **Return types** — match the Erlang typespec (e.g., `{ok, pid()}` → `Result<Pid<'Msg>, string>`)
 - **Arity** — ensure all arities of a function are covered or the most common ones are bound
 - **Charlist vs binary** — the docs say `string()` for charlists; F# strings are binaries, so convert
+- **Discrete atom sets** — model as plain DUs with no fields (add `[<CompiledName>]` for snake_case atoms)
+- **Callbacks** — use `System.Func<>` / `System.Action<>` (not raw F# function types) to avoid Emit positional bugs
 
 ## Quick Reference
 
@@ -27,6 +31,28 @@ When writing or reviewing a binding, check:
 | `[<Emit>]` on abstract member | Override `ImportAll` codegen for specific methods | `fable_utils:new_ref(...)` wrapping |
 | `System.Func<>` / `System.Action` | Typed callbacks in `ImportAll` interfaces | `fold`, `filter`, `foreach` |
 | `U2<>` / `U3<>` / erased union | Parameters or returns that accept multiple types | timeout: `int` or `infinity` |
+| Regular DU (no fields) | Discrete atom sets (table types, log levels) | `type EtsTableType = Set \| Bag \| ...` |
+| `Dynamic` + `Decode` combinators | Genuinely unknown Erlang terms | `binaryToTerm`, `application:get_env` |
+
+## Core Rule: Avoid `obj`
+
+`obj` is the maximum-entropy type — it admits any value, so using it in a binding signature
+defeats the purpose of typed bindings. When adding new bindings, treat `obj` as a last resort.
+Reach for the most specific type that fits, in this order:
+
+1. **A concrete F# type** — `int`, `string`, `bool`, `Atom`, `unit`
+2. **A generic type parameter** — `'Args`, `'Msg`, `'Key`, `'Value` when callers pick the type
+3. **A phantom-typed opaque handle** — `Pid<'Msg>`, `Ref<'Tag>`, `TableId<'K, 'R>`, `ServerRef<'Call, 'Cast>`
+4. **A plain F# DU** for discrete atom sets — compiles directly to atoms (see "DU cases compile to atoms")
+5. **A record** for structured Erlang maps — compiles to `#{field => value}` with atom keys
+6. **An erased DU `[<Erase>] type X = X of obj`** for opaque tagged wrappers (e.g., `WsFrame`, `ServerName`)
+7. **`U2<A, B>` / `U3<A, B, C>`** for parameters or returns that accept multiple known types
+8. **`Dynamic` + `Decode` combinators** for values whose shape is not known until runtime
+
+**Never** write `type X = obj` — a bare alias silently admits anything. Use `[<Erase>] type X = X of obj`
+instead; the erased DU has zero runtime cost but prevents accidental mixing with other untyped terms.
+
+The only narrow places `obj` is acceptable are listed in the "When `obj` is acceptable" section below.
 
 ## Type Mappings: F# to Erlang
 
@@ -162,30 +188,138 @@ type HttpResponse =
 F# records compile to Erlang maps with snake_case field names, so this roundtrips
 cleanly.
 
-### Opaque types: use `[<Erase>]` DUs to distinguish Erlang references
+### Opaque types: use `[<Erase>]` DUs with phantom type parameters
 
 When Erlang has multiple kinds of opaque handles (pids, refs, table IDs, timer refs),
-wrap each in its own erased type so they can't be mixed up:
+wrap each in its own erased type so they can't be mixed up. **Always add a phantom
+type parameter** to capture additional information the F# type system can reason about:
 
 ```fsharp
-[<Erase>] type Pid = Pid of obj
-[<Erase>] type Ref = Ref of obj
-[<Erase>] type TableId = TableId of obj
-[<Erase>] type TimerRef = TimerRef of obj
-[<Erase>] type SslOptions = SslOptions of obj
+/// Phantom 'Msg captures the message type this process accepts.
+[<Erase>] type Pid<'Msg> = Pid of obj
+
+/// Phantom 'Tag captures what the reference refers to (e.g., Ref<Pid<'Msg>> for a monitor).
+[<Erase>] type Ref<'Tag> = Ref of obj
+
+/// Phantom 'Msg captures the message delivered when the timer fires.
+[<Erase>] type TimerRef<'Msg> = TimerRef of obj
+
+/// Phantom 'Key and 'Row capture the ETS table's key and stored-row types.
+[<Erase>] type TableId<'Key, 'Row> = TableId of obj
+
+/// Phantom 'Call and 'Cast capture the gen_server's call/cast message types.
+[<Erase>] type ServerRef<'Call, 'Cast> = ServerRef of obj
 ```
 
-Then use them in signatures:
+Then propagate the phantom through consuming functions:
 
 ```fsharp
-// GOOD — can't accidentally pass a Ref where a Pid is expected
-[<Emit("erlang:monitor(process, $0)")>]
-let monitor (pid: Pid) : Ref = nativeOnly
+// GOOD — phantom enforces that the sent message matches the process's mailbox type
+[<Emit("$0 ! $1")>]
+let send (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
 
-// BAD — no compile-time safety
+// GOOD — monitor returns a Ref tagged with the monitored Pid
 [<Emit("erlang:monitor(process, $0)")>]
-let monitor (pid: obj) : obj = nativeOnly
+let monitor (pid: Pid<'Msg>) : Ref<Pid<'Msg>> = nativeOnly
+
+// BAD — no compile-time safety, any term can be sent
+let send (pid: obj) (msg: obj) : unit = nativeOnly
 ```
+
+For **constructor functions** that return a phantom-typed value, declare the generic
+explicitly (`<'Msg>`) so F# generalizes properly across bindings. Without it, F# value
+restriction may reject call sites:
+
+```fsharp
+// GOOD — explicit generic lets F# generalize across call sites
+[<Emit("erlang:self()")>]
+let self<'Msg> () : Pid<'Msg> = nativeOnly
+
+// Subtly wrong — value restriction can make this non-generalizable
+// let self () : Pid<'Msg> = nativeOnly
+```
+
+**Key caveat**: phantom typing guarantees *local F# consistency*, not cross-module
+correctness. A `Pid<int>` that was constructed for a process actually expecting strings
+is a lie the compiler cannot detect. Gate phantom construction through smart constructors
+where possible (`spawn`, `whereis`, `makeRef<'Tag>`).
+
+### DU cases compile to atoms (no `[<StringEnum>]` needed)
+
+Plain F# discriminated union cases **without fields** compile directly to Erlang atoms on
+Fable BEAM. The default rule is: **lowercase the first letter** of the case name.
+
+```fsharp
+type RandAlg =
+    | Exsss       // → atom exsss
+    | Exro928ss   // → atom exro928ss
+    | Exs1024s    // → atom exs1024s
+```
+
+Use this for discrete atom sets: table types, log levels, protocol atoms, option flags.
+Callers get compile-time checking that they're passing a valid atom — typos surface as
+F# errors instead of runtime `function_clause`.
+
+For **multi-word atom names** where the default lowercased first letter isn't right,
+use `[<CompiledName>]`:
+
+```fsharp
+type EtsTableType =
+    | Set                                             // → atom set
+    | [<CompiledName("ordered_set")>] OrderedSet      // → atom ordered_set
+    | Bag                                             // → atom bag
+    | [<CompiledName("duplicate_bag")>] DuplicateBag  // → atom duplicate_bag
+```
+
+Verified: `[<CompiledName>]` on DU cases works on Fable BEAM (see `TestEts.fs` and
+`TestRand.fs` for round-trip confirmation via `term_to_binary`/`binary_to_term`).
+
+Keep all cases field-less when the DU represents an atom set. DUs *with* fields compile
+to tagged tuples (`Local of Atom` → `{local, Atom}`), which is useful for tagged unions
+but mixes two behaviours if the same type has both forms.
+
+### `Dynamic` + `Decode` combinators for unknown shapes
+
+When an Erlang function returns something whose shape isn't known statically, return
+`Dynamic` instead of `obj`. Callers are forced through the `Decode` combinators to extract
+typed values — validation localised at the boundary, not sprinkled through the codebase.
+
+```fsharp
+// Binding
+[<Emit("erlang:binary_to_term($0)")>]
+let binaryToTerm (bin: string) : Dynamic = nativeOnly
+
+// Caller narrows with decoders
+let d = Erlang.binaryToTerm payload
+
+match Decode.int d with
+| Ok n -> printfn "got int %d" n
+| Error msg -> eprintfn "decode failed: %s" msg
+```
+
+Available combinators (see `src/otp/Dynamic.fs`):
+
+| Combinator | Signature |
+| --- | --- |
+| `Decode.int` / `float` / `bool` / `atom` / `string` | `Dynamic -> Result<T, string>` |
+| `Decode.dynamic` | `Dynamic -> Result<Dynamic, string>` (identity) |
+| `Decode.field` | `Atom -> Func<Dynamic, Result<V, string>> -> Dynamic -> Result<V, string>` |
+| `Decode.list` | `Func<Dynamic, Result<V, string>> -> Dynamic -> Result<V array, string>` |
+| `Decode.optional` | `Func<Dynamic, Result<V, string>> -> Dynamic -> Result<V option, string>` |
+| `Decode.tuple2` | `Func<..A..> -> Func<..B..> -> Dynamic -> Result<A * B, string>` |
+| `Decode.succeed` / `map` / `andThen` | Result combinators |
+
+Composing a record decoder:
+
+```fsharp
+let userDecoder (d: Dynamic) : Result<User, string> =
+    Decode.field (Atom "name") (System.Func<_, _> Decode.string) d
+    |> Result.bind (fun name ->
+        Decode.field (Atom "age") (System.Func<_, _> Decode.int) d
+        |> Result.map (fun age -> { Name = name; Age = age }))
+```
+
+`System.Func` is used for decoder callbacks — see "Curried Emit gotcha" below.
 
 ### Functions: use F# function types for callbacks
 
@@ -269,34 +403,51 @@ the value is passed through unchanged — no wrapping or tagging.
 
 ### When `obj` is acceptable
 
-Use `obj` only when the type is genuinely dynamic or polymorphic in Erlang:
+**Very narrow** use cases only. The default for anything "polymorphic" should be a
+generic parameter or `Dynamic`, not `obj`. Acceptable uses:
 
-- **Process dictionary** — keys and values can be anything: `put (key: obj) (value: obj)`
-- **Message passing** — messages are untyped: `send (pid: Pid) (msg: obj)`
-- **Generic containers** — when the Erlang API is polymorphic and you can't express
-  the type constraint in F#
-- **Raw `ImportAll` interfaces** — where the typed API is provided separately via
-  `[<Emit>]` helpers (the raw binding acts as an escape hatch)
+- **Genuinely type-irrelevant built-ins** — `phash2(Term, Range) -> int`, `exactEquals`
+  already fall back to `obj` or a free generic because any term is valid; wrapping every
+  call site in `Dynamic` would yield zero benefit.
+- **Backing field of an erased DU** — `[<Erase>] type Pid<'Msg> = Pid of obj`. The user
+  never sees this; the phantom is what matters.
+- **Raw `IExports` escape hatches** — when the main API is a typed helper and the raw
+  `IExports` is reserved as a fallback (e.g., `File.fs`).
+
+For everything else that feels "polymorphic":
+
+- **Caller decides the type?** → generic parameter (`'T`, `'Args`, `'Msg`).
+- **Process dictionary / message passing?** → generic (`get<'Key, 'Value>`, `send (pid: Pid<'Msg>) (msg: 'Msg)`).
+- **Unknown Erlang term?** → `Dynamic` and let the caller decode.
+- **Multiple known types?** → `U2<A, B>` or a custom erased union.
+- **Opaque reference?** → `[<Erase>] type X<'phantom> = X of obj`.
+
+**Never** write `type X = obj` (a bare alias). Use `[<Erase>] type X = X of obj` instead.
 
 ### Type choice decision tree
 
 ```text
 Is the Erlang type...
-├── a number?              → int, float, or int64
-├── a string/binary?       → string
-├── a boolean atom?        → bool
-├── the atom 'ok'?         → unit
-├── a fixed-size tuple?    → T1 * T2 * ...
-├── a list of known type?  → T list (Emit) or T array (ImportAll)
-├── an Erlang list handle? → BeamList<T> (stays in Erlang list land)
-├── an Erlang map?         → BeamMap<K, V> (generic erased type)
-├── {ok, V} | {error, R}? → Result<T, E>
-├── value | sentinel?      → T option (return undefined for None)
-├── a map with known keys? → F# record
-├── an opaque handle?      → [<Erase>] type Foo = Foo of obj
-├── a callback fun?        → System.Func (ImportAll) or F# function (Emit)
-├── one of N known types?  → U2<A,B> / U3<A,B,C> or custom erased union
-└── genuinely dynamic?     → obj (last resort)
+├── a number?                   → int, float, int64
+├── a binary/string?            → string
+├── a boolean atom?             → bool
+├── the atom 'ok'?              → unit
+├── a fixed-size tuple?         → T1 * T2 * ... (or Decode.tuple2/3 from Dynamic)
+├── a known atom set?           → plain DU (no fields), [<CompiledName>] for snake_case
+├── an open atom?               → Atom
+├── {ok, V} | {error, R}?       → Result<T, string> (Emit wraps the tuple shape)
+├── value | undefined?          → T option (IIFE converts undefined → None)
+├── a map with known keys?      → F# record (compiles to #{field => value})
+├── a map with arbitrary keys?  → BeamMap<K, V>
+├── a list of known type?       → BeamList<T>  (or T array when you need F# array ops)
+├── a list of tuples?           → BeamList<A * B>
+├── an opaque handle?           → [<Erase>] type Foo<'phantom> = Foo of obj
+├── one of N known types?       → U2<A,B> / U3<A,B,C> or custom erased union + op_ErasedCast
+├── a callback fun?             → System.Func<...> or System.Action<...>
+├── a heterogeneous tagged tuple? → [<Erase>] DU + [<Emit>] constructors (see WsFrame, ServerName)
+├── a discrete atom enumeration? → plain DU (no fields); see RandAlg, EtsTableType
+├── genuinely unknown at runtime? → Dynamic + Decode combinators (never bare obj)
+└── truly caller-polymorphic?   → 'T (never bare obj)
 ```
 
 ## Pattern 1: `[<Emit>]` — Inline Erlang Code
@@ -485,32 +636,38 @@ let readFile (path: string) : Result<string, string> = nativeOnly
 
 ## Defining Opaque Types
 
-Wrap Erlang opaque types in `[<Erase>]` single-case discriminated unions.
-This gives you compile-time type safety with zero runtime overhead:
+Wrap Erlang opaque types in `[<Erase>]` single-case discriminated unions **with a phantom
+type parameter**. This gives compile-time type safety with zero runtime overhead, and the
+phantom lets the F# type system carry additional information across call sites (see the
+earlier "Opaque types" section for full guidance on phantom parameters).
 
 ```fsharp
-/// Erlang process identifier.
+/// Erlang process identifier. 'Msg captures the mailbox message type.
 [<Erase>]
-type Pid = Pid of obj
+type Pid<'Msg> = Pid of obj
 
-/// Erlang reference (from make_ref, monitor, etc.).
+/// Erlang reference. 'Tag captures what the reference refers to.
 [<Erase>]
-type Ref = Ref of obj
+type Ref<'Tag> = Ref of obj
 
-/// Erlang atom.
+/// Erlang atom. (Atom does not need a phantom — all atoms are the same kind.)
 [<Erase>]
 type Atom = Atom of obj
 
-/// ETS table identifier.
+/// ETS table identifier. 'Key and 'Row capture the stored tuple shape.
 [<Erase>]
-type TableId = TableId of obj
+type TableId<'Key, 'Row> = TableId of obj
 ```
 
-For truly opaque types where you don't need to wrap/unwrap, use a
-simple type alias:
+For bindings that don't benefit from a phantom (the handle is truly opaque and not
+parameterised over anything), still wrap in a single-case `[<Erase>]` DU — **never use a
+bare `type X = obj` alias** (see the anti-patterns section):
 
 ```fsharp
-/// Cowboy request object (opaque).
+// GOOD
+[<Erase>] type Req = Req of obj
+
+// BAD — silently admits any obj
 type Req = obj
 ```
 
@@ -721,6 +878,135 @@ wrappers around private Emit functions. Fable compiles cross-module
 non-Emit calls as Erlang module calls (e.g., `httpc:get/3`), which won't
 exist in the target Erlang module.
 
+### Curried Emit + function-valued param: use `System.Func`
+
+When an Emit-bound function is **curried** AND takes a **function-valued argument**,
+Fable-BEAM can misplace positional `$N` substitutions in the generated Erlang. The symptom
+is the decoder fn appearing where another argument should be — typically manifesting as a
+runtime `{badmap, #Fun<...>}` or `badarity` error.
+
+**Fix**: wrap callback parameters as `System.Func<>` (matches the existing `Lists.fs`
+convention for `map`, `filter`, `foldl`):
+
+```fsharp
+// BAD — curried signature with raw F# function type. Positional $N may be swapped.
+[<Emit("(fun() -> case maps:find($0, $2) of {ok, V__} -> $1(V__); ... end end)()")>]
+let field (key: Atom) (decoder: Dynamic -> Result<'V, string>) (d: Dynamic) : Result<'V, string>
+// Generated (wrong): maps:find(Key, <decoder-fun>)   ← $1 and $2 swapped
+
+// GOOD — System.Func makes the decoder a single .NET value; substitutions are correct.
+[<Emit("(fun() -> case maps:find($0, $2) of {ok, V__} -> $1(V__); ... end end)()")>]
+let field (key: Atom) (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic)
+    : Result<'V, string>
+// Generated (correct): maps:find(Key, D)
+```
+
+Call site: `Decode.field key (System.Func<_, _> Decode.int) d`.
+
+The alternative is to switch the whole function to **tupled args**:
+
+```fsharp
+let field (key: Atom, decoder: Dynamic -> Result<'V, string>, d: Dynamic) : Result<'V, string>
+// Call site: Decode.field (key, Decode.int, d)
+```
+
+`System.Func` is preferred when the function is a natural fit for curried partial
+application and there are multiple callbacks in the same module's API (consistency with
+`Lists.fs`).
+
+## Anti-patterns
+
+Things to avoid when writing new bindings:
+
+### Anti-pattern: `type X = obj`
+
+A bare alias makes `X` freely interchangeable with any `obj`, offering no type safety at
+all. Always wrap in an erased DU instead:
+
+```fsharp
+// BAD
+type Req = obj
+
+// GOOD
+[<Erase>] type Req = Req of obj
+```
+
+The `[<Erase>]` DU compiles away at runtime (zero cost) but prevents `obj` values from
+silently flowing into a `Req`-typed slot.
+
+### Anti-pattern: `obj list` as an options bag
+
+```fsharp
+// BAD — no type safety on what goes in the list
+abstract new_: name: Atom * options: obj list -> TableId<'K, 'R>
+```
+
+Options lists in Erlang are usually heterogeneous but drawn from a closed set of shapes.
+Model the shapes explicitly. Either use a plain DU (when all options are atoms):
+
+```fsharp
+type EtsTableType = Set | OrderedSet | Bag | DuplicateBag
+abstract new_: name: Atom * options: EtsTableType list -> TableId<'K, 'R>
+```
+
+Or define a marker interface plus `[<Erase>]` static constructors (for heterogeneous
+options including tuples like `{keypos, N}`):
+
+```fsharp
+type IEtsOption = interface end
+
+[<Erase>]
+type EtsOption =
+    static member inline named_table: IEtsOption = unbox "named_table"
+    static member inline tableType (t: EtsTableType): IEtsOption = unbox t
+    static member inline keypos (n: int): IEtsOption = unbox (box (Atom "keypos", n))
+```
+
+### Anti-pattern: `obj` as handler state
+
+```fsharp
+// BAD — state is untyped; callers lose type info across handler boundaries
+let ok (req: Req) (state: obj) : obj = nativeOnly
+```
+
+Handler callbacks thread a user-controlled state across invocations. Make it generic:
+
+```fsharp
+// GOOD — 'State is inferred from caller; the handler result carries it
+[<Erase>] type HandlerResult<'State> = HandlerResult of obj
+
+[<Emit("{ok, $0, $1}")>]
+let ok (req: Req) (state: 'State) : HandlerResult<'State> = nativeOnly
+```
+
+### Anti-pattern: returning `obj` from an OTP call
+
+```fsharp
+// BAD — caller has no guidance on what the return actually is
+abstract get_env: app: Atom * key: Atom -> obj
+```
+
+Prefer one of:
+
+- **`Dynamic`** if the value is genuinely unknown — caller decodes.
+- **Typed `Result<T, string>`** if the Erlang returns `{ok, V} | {error, R}` with an IIFE
+  Emit wrapping.
+- **Record** if the return is a map with known keys.
+- **`T option`** if the return is `V | undefined` (IIFE converts the sentinel).
+
+### Anti-pattern: boxing at call sites just to satisfy `obj`
+
+If you find yourself writing `Erlang.foo (box value)` routinely, the binding is under-typed.
+Add a generic parameter so `value` flows through without the `box`:
+
+```fsharp
+// BAD — forces box at every call site
+let send (pid: Pid) (msg: obj) : unit = nativeOnly
+
+// GOOD — types flow naturally
+let send (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
+```
+
 ## Module File Template
 
 ```fsharp
@@ -729,47 +1015,60 @@ exist in the target Erlang module.
 module Fable.Beam.ModuleName
 
 open Fable.Core
-open Fable.Beam.Erlang  // if you need Pid, Ref, Atom, etc.
+open Fable.Beam  // for Atom, Pid, Ref, TimerRef, Dynamic, ...
 
 // fsharplint:disable MemberNames
 
 // ============================================================================
-// Opaque types (if any)
+// Opaque types (add phantom type parameters!)
 // ============================================================================
 
+/// Erased handle — phantom 'Tag carries additional compile-time info.
 [<Erase>]
-type MyHandle = MyHandle of obj
+type MyHandle<'Tag> = MyHandle of obj
 
 // ============================================================================
-// Raw module binding
+// Discrete atom sets (plain DUs compile to atoms)
+// ============================================================================
+
+/// Options for MyOp. Each case compiles to an Erlang atom.
+type MyOpFlag =
+    | Simple                                        // → atom simple
+    | [<CompiledName("with_log")>] WithLog          // → atom with_log
+
+// ============================================================================
+// Raw module binding — prefer typed helpers below for new code
 // ============================================================================
 
 [<Erase>]
 type IExports =
-    /// Does something.
-    abstract do_something: arg: obj -> obj
+    /// Does something. Use the typed `doSomething` below in new code.
+    abstract do_something: arg: 'Arg -> obj
 
 [<ImportAll("module_name")>]
 let moduleName: IExports = nativeOnly
 
 // ============================================================================
-// Typed API (if raw binding needs conversion)
+// Typed API (Result return for {ok, V} | {error, R} shapes)
 // ============================================================================
 
-[<Emit("""
-(fun() ->
-    case module_name:do_something($0) of
-        {ok, DoSomethingResult__} -> {ok, DoSomethingResult__};
-        {error, DoSomethingReason__} -> {error, erlang:atom_to_binary(DoSomethingReason__)}
-    end
-end)()
-""")>]
+/// WORKAROUND: IIFE wrapping required for case expressions until Fable fixes
+/// the "unsafe variable" bug. Keep (fun() -> ... end)() around Emit cases.
+[<Emit("(fun() -> case module_name:do_something($0) of {ok, Result__} -> {ok, Result__}; {error, Reason__} -> {error, erlang:atom_to_binary(Reason__)} end end)()")>]
 let doSomething (arg: string) : Result<string, string> = nativeOnly
+
+// ============================================================================
+// For unknown-shape returns — return Dynamic, not obj
+// ============================================================================
+
+[<Emit("module_name:get_info($0)")>]
+let getInfo (arg: string) : Dynamic = nativeOnly
 ```
 
 ## Complete Example: Binding a New OTP Module
 
-Here's how you'd bind `crypto` (a module not yet in Fable.Beam):
+Here's how you'd bind `crypto` (a module not yet in Fable.Beam), following every typing
+convention in this guide:
 
 ```fsharp
 /// Type bindings for Erlang crypto module
@@ -777,37 +1076,61 @@ Here's how you'd bind `crypto` (a module not yet in Fable.Beam):
 module Fable.Beam.Crypto
 
 open Fable.Core
-open Fable.Beam.Erlang
+open Fable.Beam
 
 // fsharplint:disable MemberNames
 
 // ============================================================================
-// Raw module binding
+// Discrete atom sets — plain DUs compile to atoms
+// ============================================================================
+
+/// Hash algorithms. Each case is a plain atom; multi-word names use [<CompiledName>].
+type HashAlg =
+    | Sha
+    | Sha224
+    | Sha256
+    | Sha384
+    | Sha512
+    | Sha3_256
+    | Md5
+    | [<CompiledName("blake2b")>] Blake2b
+    | [<CompiledName("blake2s")>] Blake2s
+
+// ============================================================================
+// Raw module binding — typed helpers below are the preferred API
 // ============================================================================
 
 [<Erase>]
 type IExports =
-    /// Computes a message digest (hash).
-    abstract hash: ``type``: Atom * data: obj -> obj
-    /// Generates N random bytes.
-    abstract strong_rand_bytes: n: int -> obj
     /// Lists supported hash algorithms.
-    abstract supports: ``type``: Atom -> obj list
+    abstract supports: ``type``: Atom -> Atom list
 
 [<ImportAll("crypto")>]
 let crypto: IExports = nativeOnly
 
 // ============================================================================
-// Typed helpers
+// Typed helpers — prefer these over the raw IExports
 // ============================================================================
+
+/// Compute a message digest using the given algorithm.
+[<Emit("crypto:hash($0, $1)")>]
+let hash (alg: HashAlg) (data: string) : string = nativeOnly
 
 /// Compute a SHA-256 hash of a binary string.
 [<Emit("crypto:hash(sha256, $0)")>]
-let sha256 (data: string) : obj = nativeOnly
+let sha256 (data: string) : string = nativeOnly
 
-/// Generate N cryptographically strong random bytes.
+/// Generate N cryptographically strong random bytes as a binary.
 [<Emit("crypto:strong_rand_bytes($0)")>]
-let randomBytes (n: int) : obj = nativeOnly
+let randomBytes (n: int) : string = nativeOnly
+```
+
+Call sites are now type-safe — a typo in the algorithm name is a compile error, and the
+`data` / result types are `string` (binaries) instead of `obj`:
+
+```fsharp
+let digest = Crypto.hash HashAlg.Sha256 "hello world"  // ok
+let digest = Crypto.hash HashAlg.Shah256 "hello world" // COMPILE ERROR — no such case
 ```
 
 Usage:

--- a/src/Fable.Beam.fsproj
+++ b/src/Fable.Beam.fsproj
@@ -12,6 +12,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="otp/Types.fs" />
+    <Compile Include="otp/Maps.fs" />
+    <Compile Include="otp/Lists.fs" />
+    <Compile Include="otp/Dynamic.fs" />
     <Compile Include="otp/Erlang.fs" />
     <Compile Include="otp/GenServer.fs" />
     <Compile Include="otp/Supervisor.fs" />
@@ -19,8 +22,6 @@
     <Compile Include="otp/Io.fs" />
     <Compile Include="otp/Logger.fs" />
     <Compile Include="otp/Ets.fs" />
-    <Compile Include="otp/Maps.fs" />
-    <Compile Include="otp/Lists.fs" />
     <Compile Include="otp/Init.fs" />
     <Compile Include="otp/Application.fs" />
     <Compile Include="otp/Binary.fs" />

--- a/src/cowboy/Cowboy.fs
+++ b/src/cowboy/Cowboy.fs
@@ -3,23 +3,24 @@
 module Fable.Beam.Cowboy.Cowboy
 
 open Fable.Core
+open Fable.Beam
 
 /// Start a clear (HTTP) listener.
 [<Emit("cowboy:start_clear($0, $1, $2)")>]
-let startClear (name: obj) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+let startClear (name: Atom) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
 
 /// Start a TLS (HTTPS) listener.
 [<Emit("cowboy:start_tls($0, $1, $2)")>]
-let startTls (name: obj) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+let startTls (name: Atom) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
 
 /// Stop a running listener.
 [<Emit("cowboy:stop_listener($0)")>]
-let stopListener (name: obj) : obj = nativeOnly
+let stopListener (name: Atom) : obj = nativeOnly
 
 /// Retrieve a listener's environment value.
 [<Emit("cowboy:get_env($0, $1)")>]
-let getEnv (name: obj) (key: obj) : obj = nativeOnly
+let getEnv (name: Atom) (key: Atom) : obj = nativeOnly
 
 /// Update a listener's environment value.
 [<Emit("cowboy:set_env($0, $1, $2)")>]
-let setEnv (name: obj) (key: obj) (value: obj) : obj = nativeOnly
+let setEnv (name: Atom) (key: Atom) (value: obj) : obj = nativeOnly

--- a/src/cowboy/CowboyHandler.fs
+++ b/src/cowboy/CowboyHandler.fs
@@ -4,6 +4,11 @@ module Fable.Beam.Cowboy.CowboyHandler
 
 open Fable.Core
 
+/// Erased wrapper for a handler callback's return value.
+/// The phantom 'State captures the handler state threaded through callbacks.
+[<Erase>]
+type HandlerResult<'State> = HandlerResult of obj
+
 /// Return {ok, Req, State} from init/2.
 [<Emit("{ok, $0, $1}")>]
-let ok (req: obj) (state: obj) : obj = nativeOnly
+let ok (req: CowboyReq.Req) (state: 'State) : HandlerResult<'State> = nativeOnly

--- a/src/cowboy/CowboyReq.fs
+++ b/src/cowboy/CowboyReq.fs
@@ -3,9 +3,13 @@
 module Fable.Beam.Cowboy.CowboyReq
 
 open Fable.Core
+open Fable.Beam
+open Fable.Beam.Maps
 
-/// Opaque Cowboy request object.
-type Req = obj
+/// Opaque Cowboy request object. Erased at runtime — prevents accidental
+/// mixing with other untyped Erlang terms.
+[<Erase>]
+type Req = Req of obj
 
 /// Get the HTTP method (e.g. <<"GET">>, <<"POST">>).
 [<Emit("cowboy_req:method($0)")>]
@@ -23,9 +27,9 @@ let header (name: string) (req: Req) : string = nativeOnly
 [<Emit("cowboy_req:header($0, $1, $2)")>]
 let headerDefault (name: string) (req: Req) (defaultValue: string) : string = nativeOnly
 
-/// Get all request headers as a map.
+/// Get all request headers as a map of binary-keyed strings.
 [<Emit("cowboy_req:headers($0)")>]
-let headers (req: Req) : obj = nativeOnly
+let headers (req: Req) : BeamMap<string, string> = nativeOnly
 
 /// Read the full request body. Returns {ok, Body, Req}.
 [<Emit("cowboy_req:read_body($0)")>]
@@ -37,11 +41,11 @@ let queryString (req: Req) : string = nativeOnly
 
 /// Send a full response: status, headers map, body, req.
 [<Emit("cowboy_req:reply($0, $1, $2, $3)")>]
-let reply (status: int) (headers: obj) (body: string) (req: Req) : Req = nativeOnly
+let reply (status: int) (headers: BeamMap<string, string>) (body: string) (req: Req) : Req = nativeOnly
 
 /// Send a response with status and headers only (no body).
 [<Emit("cowboy_req:reply($0, $1, $2)")>]
-let replyNoBody (status: int) (headers: obj) (req: Req) : Req = nativeOnly
+let replyNoBody (status: int) (headers: BeamMap<string, string>) (req: Req) : Req = nativeOnly
 
 /// Get the peer IP address and port.
 [<Emit("cowboy_req:peer($0)")>]
@@ -65,8 +69,8 @@ let parseQs (req: Req) : obj = nativeOnly
 
 /// Get a binding value from the route.
 [<Emit("cowboy_req:binding($0, $1)")>]
-let binding (name: obj) (req: Req) : obj = nativeOnly
+let binding (name: Atom) (req: Req) : string = nativeOnly
 
 /// Get a binding value with a default.
 [<Emit("cowboy_req:binding($0, $1, $2)")>]
-let bindingDefault (name: obj) (req: Req) (defaultValue: obj) : obj = nativeOnly
+let bindingDefault (name: Atom) (req: Req) (defaultValue: string) : string = nativeOnly

--- a/src/cowboy/CowboyRouter.fs
+++ b/src/cowboy/CowboyRouter.fs
@@ -3,15 +3,18 @@
 module Fable.Beam.Cowboy.CowboyRouter
 
 open Fable.Core
+open Fable.Beam
 
 /// Compile routing rules into a dispatch list.
 [<Emit("cowboy_router:compile($0)")>]
 let compile (routes: obj) : obj = nativeOnly
 
 /// Route: {Path, Handler, InitialState}.
+/// Handler is the module atom that implements the cowboy_handler behaviour.
 [<Emit("{$0, $1, $2}")>]
-let route (path: string) (handler: obj) (state: obj) : obj = nativeOnly
+let route (path: string) (handler: Atom) (state: 'State) : obj = nativeOnly
 
 /// Host rule: {HostMatch, Routes}.
+/// HostMatch is typically a binary pattern or the atom '_' for wildcard.
 [<Emit("{$0, $1}")>]
 let hostRule (host: obj) (routes: obj list) : obj = nativeOnly

--- a/src/cowboy/CowboyWebsocket.fs
+++ b/src/cowboy/CowboyWebsocket.fs
@@ -4,50 +4,59 @@ module Fable.Beam.Cowboy.CowboyWebsocket
 
 open Fable.Core
 
-// -- Handler return types --
+/// Erased wrapper for a WebSocket frame. Use the helpers below to construct.
+[<Erase>]
+type WsFrame = WsFrame of obj
 
-/// Return {cowboy_websocket, Req, State} from init/2 to upgrade to WebSocket.
-[<Emit("{cowboy_websocket, $0, $1}")>]
-let upgrade (req: obj) (state: obj) : obj = nativeOnly
-
-/// Return {cowboy_websocket, Req, State, Opts} from init/2 with options.
-[<Emit("{cowboy_websocket, $0, $1, $2}")>]
-let upgradeWithOpts (req: obj) (state: obj) (opts: obj) : obj = nativeOnly
-
-/// Return {ok, State} from websocket_init/1 or websocket_handle/2.
-[<Emit("{ok, $0}")>]
-let ok (state: obj) : obj = nativeOnly
-
-/// Return {reply, Frame, State} to send a single frame.
-[<Emit("{reply, $0, $1}")>]
-let reply (frame: obj) (state: obj) : obj = nativeOnly
-
-/// Return {reply, Frames, State} to send multiple frames.
-[<Emit("{reply, $0, $1}")>]
-let replyMany (frames: obj list) (state: obj) : obj = nativeOnly
-
-/// Return {stop, State} to close the WebSocket connection.
-[<Emit("{stop, $0}")>]
-let stop (state: obj) : obj = nativeOnly
+/// Erased wrapper for a WebSocket callback's return value.
+/// The phantom 'State captures the handler state.
+[<Erase>]
+type WsResult<'State> = WsResult of obj
 
 // -- Frame constructors --
 
 /// Create a text frame: {text, Data}.
 [<Emit("{text, $0}")>]
-let textFrame (data: string) : obj = nativeOnly
+let textFrame (data: string) : WsFrame = nativeOnly
 
 /// Create a binary frame: {binary, Data}.
 [<Emit("{binary, $0}")>]
-let binaryFrame (data: obj) : obj = nativeOnly
+let binaryFrame (data: byte array) : WsFrame = nativeOnly
 
 /// Create a ping frame.
 [<Emit("ping")>]
-let pingFrame: obj = nativeOnly
+let pingFrame: WsFrame = nativeOnly
 
 /// Create a pong frame.
 [<Emit("pong")>]
-let pongFrame: obj = nativeOnly
+let pongFrame: WsFrame = nativeOnly
 
 /// Create a close frame: {close, Code, Reason}.
 [<Emit("{close, $0, $1}")>]
-let closeFrame (code: int) (reason: string) : obj = nativeOnly
+let closeFrame (code: int) (reason: string) : WsFrame = nativeOnly
+
+// -- Handler return types --
+
+/// Return {cowboy_websocket, Req, State} from init/2 to upgrade to WebSocket.
+[<Emit("{cowboy_websocket, $0, $1}")>]
+let upgrade (req: CowboyReq.Req) (state: 'State) : WsResult<'State> = nativeOnly
+
+/// Return {cowboy_websocket, Req, State, Opts} from init/2 with options.
+[<Emit("{cowboy_websocket, $0, $1, $2}")>]
+let upgradeWithOpts (req: CowboyReq.Req) (state: 'State) (opts: obj) : WsResult<'State> = nativeOnly
+
+/// Return {ok, State} from websocket_init/1 or websocket_handle/2.
+[<Emit("{ok, $0}")>]
+let ok (state: 'State) : WsResult<'State> = nativeOnly
+
+/// Return {reply, Frame, State} to send a single frame.
+[<Emit("{reply, $0, $1}")>]
+let reply (frame: WsFrame) (state: 'State) : WsResult<'State> = nativeOnly
+
+/// Return {reply, Frames, State} to send multiple frames.
+[<Emit("{reply, $0, $1}")>]
+let replyMany (frames: WsFrame list) (state: 'State) : WsResult<'State> = nativeOnly
+
+/// Return {stop, State} to close the WebSocket connection.
+[<Emit("{stop, $0}")>]
+let stop (state: 'State) : WsResult<'State> = nativeOnly

--- a/src/cowboy/Fable.Beam.Cowboy.fsproj
+++ b/src/cowboy/Fable.Beam.Cowboy.fsproj
@@ -11,11 +11,14 @@
     <Description>Fable bindings for Cowboy HTTP server on BEAM</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Cowboy.fs" />
-    <Compile Include="CowboyHandler.fs" />
+    <ProjectReference Include="..\Fable.Beam.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="CowboyReq.fs" />
-    <Compile Include="CowboyRouter.fs" />
+    <Compile Include="CowboyHandler.fs" />
     <Compile Include="CowboyWebsocket.fs" />
+    <Compile Include="CowboyRouter.fs" />
+    <Compile Include="Cowboy.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />

--- a/src/otp/Application.fs
+++ b/src/otp/Application.fs
@@ -7,6 +7,7 @@ open Fable.Beam
 
 // fsharplint:disable MemberNames
 
+/// Raw low-level bindings. Prefer the typed helpers below for most use cases.
 [<Erase>]
 type IExports =
     /// Starts an application and all its dependencies.
@@ -18,12 +19,36 @@ type IExports =
     /// Gets an application environment variable.
     abstract get_env: app: Atom * key: Atom -> obj
     /// Gets an application environment variable with default.
-    abstract get_env: app: Atom * key: Atom * defaultValue: obj -> obj
+    abstract get_env: app: Atom * key: Atom * defaultValue: 'V -> 'V
     /// Sets an application environment variable.
-    abstract set_env: app: Atom * key: Atom * value: obj -> obj
+    abstract set_env: app: Atom * key: Atom * value: 'V -> unit
     /// Returns a list of all running applications.
     abstract which_applications: unit -> obj
 
 /// application module
 [<ImportAll("application")>]
 let application: IExports = nativeOnly
+
+// ============================================================================
+// Typed API
+// ============================================================================
+// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
+// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+
+/// Gets an application environment variable. Returns None if unset.
+/// The returned Dynamic must be decoded with `Fable.Beam.Decode` combinators.
+[<Emit("(fun() -> case application:get_env($0, $1) of {ok, GetEnvVal__} -> GetEnvVal__; undefined -> undefined end end)()")>]
+let getEnv (app: Atom) (key: Atom) : Dynamic option = nativeOnly
+
+/// Starts an application and all its dependencies. Returns the list of apps
+/// that were started (empty if everything was already running).
+[<Emit("(fun() -> case application:ensure_all_started($0) of {ok, Started__} -> {ok, fable_utils:new_ref(Started__)}; {error, Reason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [Reason__]))} end end)()")>]
+let ensureAllStarted (app: Atom) : Result<Atom array, string> = nativeOnly
+
+/// Starts an application (without dependencies). Returns Ok on success.
+[<Emit("(fun() -> case application:start($0) of ok -> {ok, ok}; {error, Reason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [Reason__]))} end end)()")>]
+let start (app: Atom) : Result<unit, string> = nativeOnly
+
+/// Stops an application. Returns Ok on success.
+[<Emit("(fun() -> case application:stop($0) of ok -> {ok, ok}; {error, Reason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [Reason__]))} end end)()")>]
+let stop (app: Atom) : Result<unit, string> = nativeOnly

--- a/src/otp/Dynamic.fs
+++ b/src/otp/Dynamic.fs
@@ -1,0 +1,98 @@
+/// A dynamically-typed Erlang term with composable decoders for extracting
+/// typed values. Use this instead of bare `obj` when the runtime shape is
+/// unknown and must be validated.
+///
+/// Inspired by Gleam's `gleam/dynamic/decode` module.
+namespace Fable.Beam
+
+open Fable.Core
+
+/// An Erlang term of unknown static type. Construct from untyped Erlang
+/// responses and narrow with the combinators in the `Decode` module.
+[<Erase>]
+type Dynamic = Dynamic of obj
+
+/// Decoder combinators for extracting typed values from a `Dynamic`.
+/// Each decoder returns `Result<'T, string>` where the error is a human-readable message.
+///
+/// WORKAROUND: Emit expressions wrapped in `(fun() -> ... end)()` to prevent
+/// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+module Decode =
+
+    /// Decode a Dynamic as an integer.
+    [<Emit("(fun() -> case erlang:is_integer($0) of true -> {ok, $0}; false -> {error, <<\"expected integer\">>} end end)()")>]
+    let int (d: Dynamic) : Result<int, string> = nativeOnly
+
+    /// Decode a Dynamic as a float.
+    [<Emit("(fun() -> case erlang:is_float($0) of true -> {ok, $0}; false -> {error, <<\"expected float\">>} end end)()")>]
+    let float (d: Dynamic) : Result<float, string> = nativeOnly
+
+    /// Decode a Dynamic as a boolean (atoms `true` or `false`).
+    [<Emit("(fun() -> case erlang:is_boolean($0) of true -> {ok, $0}; false -> {error, <<\"expected boolean\">>} end end)()")>]
+    let bool (d: Dynamic) : Result<bool, string> = nativeOnly
+
+    /// Decode a Dynamic as an atom.
+    [<Emit("(fun() -> case erlang:is_atom($0) of true -> {ok, $0}; false -> {error, <<\"expected atom\">>} end end)()")>]
+    let atom (d: Dynamic) : Result<Atom, string> = nativeOnly
+
+    /// Decode a Dynamic as a binary string.
+    [<Emit("(fun() -> case erlang:is_binary($0) of true -> {ok, $0}; false -> {error, <<\"expected binary string\">>} end end)()")>]
+    let string (d: Dynamic) : Result<string, string> = nativeOnly
+
+    /// Return the Dynamic unchanged. Useful as a terminal decoder in `field`
+    /// chains when you want to hand off further decoding to the caller.
+    [<Emit("{ok, $0}")>]
+    let dynamic (d: Dynamic) : Result<Dynamic, string> = nativeOnly
+
+    /// Extract a field from an Erlang map and decode it with the given decoder.
+    /// Returns Error if the map doesn't contain the key or the inner decoder fails.
+    /// Uses System.Func for the decoder — matches the Lists.fs convention for
+    /// callbacks and avoids curried-arg substitution issues with Emit.
+    [<Emit("(fun() -> case maps:find($0, $2) of {ok, FieldVal__} -> $1(FieldVal__); error -> {error, erlang:list_to_binary(io_lib:format(<<\"missing field ~p\">>, [$0]))} end end)()")>]
+    let field
+        (key: Atom)
+        (decoder: System.Func<Dynamic, Result<'V, string>>)
+        (d: Dynamic)
+        : Result<'V, string> =
+        nativeOnly
+
+    /// Decode a Dynamic as a list of values, decoding each element with `decoder`.
+    /// Short-circuits on the first decode error.
+    /// Decode a Dynamic as a list of values, decoding each element with `decoder`.
+    /// Short-circuits on the first decode error.
+    [<Emit("(fun() -> case erlang:is_list($1) of true -> DecodeListFold__ = fun (_, {error, _} = E__) -> E__; (Elem__, {ok, Acc__}) -> case $0(Elem__) of {ok, V__} -> {ok, [V__ | Acc__]}; {error, _} = E__ -> E__ end end, case lists:foldl(DecodeListFold__, {ok, []}, $1) of {ok, Rev__} -> {ok, fable_utils:new_ref(lists:reverse(Rev__))}; {error, _} = E__ -> E__ end; false -> {error, <<\"expected list\">>} end end)()")>]
+    let list
+        (decoder: System.Func<Dynamic, Result<'V, string>>)
+        (d: Dynamic)
+        : Result<'V array, string> =
+        nativeOnly
+
+    /// Decode a Dynamic that may be the atom `undefined` (mapped to None) or
+    /// a value decoded by the inner decoder (mapped to Some).
+    [<Emit("(fun() -> case $1 of undefined -> {ok, undefined}; V__ -> case $0(V__) of {ok, V2__} -> {ok, V2__}; {error, _} = E__ -> E__ end end end)()")>]
+    let optional
+        (decoder: System.Func<Dynamic, Result<'V, string>>)
+        (d: Dynamic)
+        : Result<'V option, string> =
+        nativeOnly
+
+    /// Decode a 2-tuple by applying each decoder to the corresponding element.
+    [<Emit("(fun() -> case erlang:is_tuple($2) andalso erlang:tuple_size($2) =:= 2 of true -> case $0(erlang:element(1, $2)) of {ok, A__} -> case $1(erlang:element(2, $2)) of {ok, B__} -> {ok, {A__, B__}}; {error, _} = E__ -> E__ end; {error, _} = E__ -> E__ end; false -> {error, <<\"expected 2-tuple\">>} end end)()")>]
+    let tuple2
+        (decA: System.Func<Dynamic, Result<'A, string>>)
+        (decB: System.Func<Dynamic, Result<'B, string>>)
+        (d: Dynamic)
+        : Result<'A * 'B, string> =
+        nativeOnly
+
+    /// Lift a plain value into the Result monad. Useful for building records
+    /// after extracting all fields successfully.
+    let inline succeed (value: 'V) : Result<'V, string> = Ok value
+
+    /// Map the successful value of a decode result through a function.
+    let inline map (f: 'A -> 'B) (r: Result<'A, string>) : Result<'B, string> = Result.map f r
+
+    /// Chain decode results: run the first, and if it succeeds, run the second
+    /// with its value.
+    let inline andThen (f: 'A -> Result<'B, string>) (r: Result<'A, string>) : Result<'B, string> =
+        Result.bind f r

--- a/src/otp/Dynamic.fs
+++ b/src/otp/Dynamic.fs
@@ -49,31 +49,18 @@ module Decode =
     /// Uses System.Func for the decoder — matches the Lists.fs convention for
     /// callbacks and avoids curried-arg substitution issues with Emit.
     [<Emit("(fun() -> case maps:find($0, $2) of {ok, FieldVal__} -> $1(FieldVal__); error -> {error, erlang:list_to_binary(io_lib:format(<<\"missing field ~p\">>, [$0]))} end end)()")>]
-    let field
-        (key: Atom)
-        (decoder: System.Func<Dynamic, Result<'V, string>>)
-        (d: Dynamic)
-        : Result<'V, string> =
+    let field (key: Atom) (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic) : Result<'V, string> =
         nativeOnly
 
     /// Decode a Dynamic as a list of values, decoding each element with `decoder`.
     /// Short-circuits on the first decode error.
-    /// Decode a Dynamic as a list of values, decoding each element with `decoder`.
-    /// Short-circuits on the first decode error.
     [<Emit("(fun() -> case erlang:is_list($1) of true -> DecodeListFold__ = fun (_, {error, _} = E__) -> E__; (Elem__, {ok, Acc__}) -> case $0(Elem__) of {ok, V__} -> {ok, [V__ | Acc__]}; {error, _} = E__ -> E__ end end, case lists:foldl(DecodeListFold__, {ok, []}, $1) of {ok, Rev__} -> {ok, fable_utils:new_ref(lists:reverse(Rev__))}; {error, _} = E__ -> E__ end; false -> {error, <<\"expected list\">>} end end)()")>]
-    let list
-        (decoder: System.Func<Dynamic, Result<'V, string>>)
-        (d: Dynamic)
-        : Result<'V array, string> =
-        nativeOnly
+    let list (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic) : Result<'V array, string> = nativeOnly
 
     /// Decode a Dynamic that may be the atom `undefined` (mapped to None) or
     /// a value decoded by the inner decoder (mapped to Some).
     [<Emit("(fun() -> case $1 of undefined -> {ok, undefined}; V__ -> case $0(V__) of {ok, V2__} -> {ok, V2__}; {error, _} = E__ -> E__ end end end)()")>]
-    let optional
-        (decoder: System.Func<Dynamic, Result<'V, string>>)
-        (d: Dynamic)
-        : Result<'V option, string> =
+    let optional (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic) : Result<'V option, string> =
         nativeOnly
 
     /// Decode a 2-tuple by applying each decoder to the corresponding element.
@@ -94,5 +81,4 @@ module Decode =
 
     /// Chain decode results: run the first, and if it succeeds, run the second
     /// with its value.
-    let inline andThen (f: 'A -> Result<'B, string>) (r: Result<'A, string>) : Result<'B, string> =
-        Result.bind f r
+    let inline andThen (f: 'A -> Result<'B, string>) (r: Result<'A, string>) : Result<'B, string> = Result.bind f r

--- a/src/otp/Erlang.fs
+++ b/src/otp/Erlang.fs
@@ -5,6 +5,7 @@ module Fable.Beam.Erlang
 
 open Fable.Core
 open Fable.Beam
+open Fable.Beam.Lists
 
 // Note: For selective receive, use Fable.Core.BeamInterop.Erlang.receive<'T>
 // which is provided by Fable.Core and handled by the compiler.
@@ -13,21 +14,21 @@ open Fable.Beam
 // Process management
 // ============================================================================
 
-/// Get the current process's pid.
+/// Get the current process's pid. Caller picks the phantom 'Msg tag.
 [<Emit("erlang:self()")>]
-let self () : Pid = nativeOnly
+let self<'Msg> () : Pid<'Msg> = nativeOnly
 
 /// Spawn a new process that executes the given function.
 [<Emit("erlang:spawn(fun() -> $0(ok) end)")>]
-let spawn (f: unit -> unit) : Pid = nativeOnly
+let spawn<'Msg> (f: unit -> unit) : Pid<'Msg> = nativeOnly
 
 /// Spawn a linked process.
 [<Emit("erlang:spawn_link(fun() -> $0(ok) end)")>]
-let spawnLink (f: unit -> unit) : Pid = nativeOnly
+let spawnLink<'Msg> (f: unit -> unit) : Pid<'Msg> = nativeOnly
 
-/// Send a message to a process (Pid ! Msg).
+/// Send a typed message to a process (Pid ! Msg).
 [<Emit("$0 ! $1")>]
-let send (pid: Pid) (msg: obj) : unit = nativeOnly
+let send (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
 
 /// Enable trap_exit so EXIT signals become messages. Returns the old value.
 [<Emit("erlang:process_flag(trap_exit, true)")>]
@@ -39,55 +40,56 @@ let processFlag (flag: Atom) (value: obj) : obj = nativeOnly
 
 /// Exit the current process with a reason.
 [<Emit("erlang:exit($0)")>]
-let exit (reason: obj) : unit = nativeOnly
+let exit (reason: 'Reason) : unit = nativeOnly
 
 /// Send an exit signal to a process.
 [<Emit("erlang:exit($0, $1)")>]
-let exitPid (pid: Pid) (reason: obj) : unit = nativeOnly
+let exitPid (pid: Pid<'Msg>) (reason: 'Reason) : unit = nativeOnly
 
 /// Link to another process.
 [<Emit("erlang:link($0)")>]
-let link (pid: Pid) : unit = nativeOnly
+let link (pid: Pid<'Msg>) : unit = nativeOnly
 
 /// Unlink from a process.
 [<Emit("erlang:unlink($0)")>]
-let unlink (pid: Pid) : unit = nativeOnly
+let unlink (pid: Pid<'Msg>) : unit = nativeOnly
 
-/// Monitor a process. Returns a monitor reference.
+/// Monitor a process. Returns a monitor reference tagged with the monitored Pid.
 [<Emit("erlang:monitor(process, $0)")>]
-let monitor (pid: Pid) : Ref = nativeOnly
+let monitor (pid: Pid<'Msg>) : Ref<Pid<'Msg>> = nativeOnly
 
 /// Demonitor a process.
 [<Emit("erlang:demonitor($0)")>]
-let demonitor (ref: Ref) : unit = nativeOnly
+let demonitor (ref: Ref<'Tag>) : unit = nativeOnly
 
 /// Demonitor a process with flush option.
 [<Emit("erlang:demonitor($0, [flush])")>]
-let demonitorFlush (ref: Ref) : unit = nativeOnly
+let demonitorFlush (ref: Ref<'Tag>) : unit = nativeOnly
 
 /// Register a name for the calling process.
 [<Emit("erlang:register($0, $1)")>]
-let register (name: Atom) (pid: Pid) : unit = nativeOnly
+let register (name: Atom) (pid: Pid<'Msg>) : unit = nativeOnly
 
 /// Look up a registered process name. Returns None if not registered.
 [<Emit("(fun() -> case erlang:whereis($0) of undefined -> undefined; WhereIsPid__ -> WhereIsPid__ end end)()")>]
-let whereis (name: Atom) : Pid option = nativeOnly
+let whereis<'Msg> (name: Atom) : Pid<'Msg> option = nativeOnly
 
 /// Check if a process is alive.
 [<Emit("erlang:is_process_alive($0)")>]
-let isProcessAlive (pid: Pid) : bool = nativeOnly
+let isProcessAlive (pid: Pid<'Msg>) : bool = nativeOnly
 
 // ============================================================================
 // References and identity
 // ============================================================================
 
-/// Create a unique reference.
+/// Create a unique reference. The caller picks the phantom tag.
 [<Emit("erlang:make_ref()")>]
-let makeRef () : Ref = nativeOnly
+let makeRef<'Tag> () : Ref<'Tag> = nativeOnly
 
-/// Exact equality comparison (=:=).
+/// Exact equality comparison (=:=). Generic 'T forces both operands to the same
+/// type — use box on one side if you really need to compare values of unrelated types.
 [<Emit("$0 =:= $1")>]
-let exactEquals (a: obj) (b: obj) : bool = nativeOnly
+let exactEquals (a: 'T) (b: 'T) : bool = nativeOnly
 
 // ============================================================================
 // Time
@@ -111,31 +113,34 @@ let phash2 (term: obj) (range: int) : int = nativeOnly
 
 /// Schedule a message to be sent to self after Ms milliseconds.
 [<Emit("erlang:send_after($0, erlang:self(), $1)")>]
-let sendAfter (ms: int) (msg: obj) : TimerRef = nativeOnly
+let sendAfter (ms: int) (msg: 'Msg) : TimerRef<'Msg> = nativeOnly
 
 /// Schedule a message to be sent to the given process after Ms milliseconds.
 [<Emit("erlang:send_after($0, $1, $2)")>]
-let sendAfterTo (ms: int) (dest: Pid) (msg: obj) : TimerRef = nativeOnly
+let sendAfterTo (ms: int) (dest: Pid<'Msg>) (msg: 'Msg) : TimerRef<'Msg> = nativeOnly
 
 /// Cancel a timer. Returns the remaining time in ms, or None if the timer was not found.
 [<Emit("(fun() -> case erlang:cancel_timer($0) of false -> undefined; CancelTimerMs__ -> CancelTimerMs__ end end)()")>]
-let cancelTimer (timerRef: TimerRef) : int option = nativeOnly
+let cancelTimer (timerRef: TimerRef<'Msg>) : int option = nativeOnly
 
 // ============================================================================
 // Process dictionary
 // ============================================================================
 
-/// Get a value from the process dictionary.
-[<Emit("erlang:get($0)")>]
-let get (key: obj) : obj = nativeOnly
+/// Get a value from the process dictionary. Returns None if the key is not set
+/// (indistinguishable from a value stored as the atom 'undefined').
+[<Emit("(fun() -> case erlang:get($0) of undefined -> undefined; GetVal__ -> GetVal__ end end)()")>]
+let get<'Key, 'Value> (key: 'Key) : 'Value option = nativeOnly
 
-/// Put a value in the process dictionary.
-[<Emit("erlang:put($0, $1)")>]
-let put (key: obj) (value: obj) : obj = nativeOnly
+/// Put a value in the process dictionary. Returns the previous value, or None
+/// if the key wasn't set.
+[<Emit("(fun() -> case erlang:put($0, $1) of undefined -> undefined; PutPrev__ -> PutPrev__ end end)()")>]
+let put<'Key, 'Value> (key: 'Key) (value: 'Value) : 'Value option = nativeOnly
 
-/// Erase a key from the process dictionary.
-[<Emit("erlang:erase($0)")>]
-let erase (key: obj) : obj = nativeOnly
+/// Erase a key from the process dictionary. Returns the previous value, or None
+/// if the key wasn't set.
+[<Emit("(fun() -> case erlang:erase($0) of undefined -> undefined; ErasePrev__ -> ErasePrev__ end end)()")>]
+let erase<'Key, 'Value> (key: 'Key) : 'Value option = nativeOnly
 
 // ============================================================================
 // Date and time
@@ -177,7 +182,7 @@ let universaltime () : (int * int * int) * (int * int * int) = nativeOnly
 /// Use this instead of .Length when working with raw Erlang lists from OTP calls,
 /// since F# .Length expects a ref-wrapped array, not a native Erlang list.
 [<Emit("erlang:length($0)")>]
-let length (list: obj) : int = nativeOnly
+let length (list: BeamList<'T>) : int = nativeOnly
 
 /// Returns the size of a tuple.
 [<Emit("erlang:tuple_size($0)")>]
@@ -197,11 +202,12 @@ let element (n: int) (tuple: obj) : obj = nativeOnly
 
 /// Convert a term to a binary string for display.
 [<Emit("erlang:term_to_binary($0)")>]
-let termToBinary (term: obj) : obj = nativeOnly
+let termToBinary (term: 'Term) : string = nativeOnly
 
-/// Convert a binary back to a term.
+/// Convert a binary back to a Dynamic term. Use `Fable.Beam.Decode` combinators
+/// to narrow the resulting Dynamic to a typed value.
 [<Emit("erlang:binary_to_term($0)")>]
-let binaryToTerm (bin: obj) : obj = nativeOnly
+let binaryToTerm (bin: string) : Dynamic = nativeOnly
 
 /// Convert a list to a binary.
 [<Emit("erlang:list_to_binary($0)")>]
@@ -218,12 +224,12 @@ let binaryToAtom (s: string) : Atom = nativeOnly
 /// Convert an atom to a charlist. Note: returns a charlist (Erlang string()),
 /// not an F# string (binary). Use atomToBinary for F# string conversion.
 [<Emit("erlang:atom_to_list($0)")>]
-let atomToList (atom: Atom) : obj = nativeOnly
+let atomToList (atom: Atom) : BeamList<int> = nativeOnly
 
 /// Convert a charlist to an atom. Note: expects a charlist (Erlang string()),
 /// not an F# string (binary). Use binaryToAtom for F# string conversion.
 [<Emit("erlang:list_to_atom($0)")>]
-let listToAtom (charlist: obj) : Atom = nativeOnly
+let listToAtom (charlist: BeamList<int>) : Atom = nativeOnly
 
 /// Format a term as a readable string.
 [<Emit("erlang:list_to_binary(io_lib:format(<<\"~p\">>, [$0]))")>]

--- a/src/otp/Ets.fs
+++ b/src/otp/Ets.fs
@@ -8,45 +8,94 @@ open Fable.Beam
 // fsharplint:disable MemberNames
 
 /// Opaque ETS table identifier.
+/// The phantom 'Key and 'Row capture the types of keys and stored rows —
+/// analogous to BeamMap<'K,'V>. Erased at runtime.
 [<Erase>]
-type TableId = TableId of obj
+type TableId<'Key, 'Row> = TableId of obj
+
+/// ETS table type. Determines key uniqueness and ordering.
+type EtsTableType =
+    | Set
+    | [<CompiledName("ordered_set")>] OrderedSet
+    | Bag
+    | [<CompiledName("duplicate_bag")>] DuplicateBag
+
+/// ETS table access level. Determines which processes can read/write the table.
+type EtsAccess =
+    | Public
+    | Protected
+    | Private
 
 [<Erase>]
 type IExports =
     /// Creates a new ETS table.
-    abstract new_: name: Atom * options: Atom list -> TableId
+    abstract new_: name: Atom * options: Atom list -> TableId<'Key, 'Row>
     /// Inserts a tuple or list of tuples into the table.
-    abstract insert: table: TableId * objects: obj -> bool
+    abstract insert: table: TableId<'Key, 'Row> * objects: 'Row -> bool
 
     /// Looks up elements with the given key.
     [<Emit("fable_utils:new_ref(ets:lookup($0, $1))")>]
-    abstract lookup: table: TableId * key: obj -> obj array
+    abstract lookup: table: TableId<'Key, 'Row> * key: 'Key -> 'Row array
 
     /// Deletes an entire table.
-    abstract delete: table: TableId -> unit
+    abstract delete: table: TableId<'Key, 'Row> -> unit
     /// Deletes all objects with key from the table.
-    abstract delete: table: TableId * key: obj -> unit
+    abstract delete: table: TableId<'Key, 'Row> * key: 'Key -> unit
 
     /// Returns a list of all objects in the table.
     [<Emit("fable_utils:new_ref(ets:tab2list($0))")>]
-    abstract tab2list: table: TableId -> obj array
+    abstract tab2list: table: TableId<'Key, 'Row> -> 'Row array
 
     /// Returns information about the table.
-    abstract info: table: TableId -> obj
+    abstract info: table: TableId<'Key, 'Row> -> obj
 
     /// Matches objects in the table against a pattern.
     [<Emit("fable_utils:new_ref(ets:'match'($0, $1))")>]
-    abstract ``match``: table: TableId * pattern: obj -> obj array
+    abstract ``match``: table: TableId<'Key, 'Row> * pattern: obj -> obj array
 
     /// Selects objects using a match specification.
     [<Emit("fable_utils:new_ref(ets:select($0, $1))")>]
-    abstract select: table: TableId * matchSpec: obj -> obj array
+    abstract select: table: TableId<'Key, 'Row> * matchSpec: obj -> obj array
 
-    /// Returns the first key in the table.
-    abstract first: table: TableId -> obj
-    /// Returns the next key after the given key.
-    abstract next: table: TableId * key: obj -> obj
+    /// Returns the first key in the table, or None if the table is empty.
+    [<Emit("(fun() -> case ets:first($0) of '$end_of_table' -> undefined; FirstKey__ -> FirstKey__ end end)()")>]
+    abstract first: table: TableId<'Key, 'Row> -> 'Key option
+    /// Returns the next key after the given key, or None if at the end.
+    [<Emit("(fun() -> case ets:next($0, $1) of '$end_of_table' -> undefined; NextKey__ -> NextKey__ end end)()")>]
+    abstract next: table: TableId<'Key, 'Row> * key: 'Key -> 'Key option
 
 /// ets module
 [<ImportAll("ets")>]
 let ets: IExports = nativeOnly
+
+// ============================================================================
+// Typed ets:info/2 accessors for common fields
+// ============================================================================
+
+/// Number of objects stored in the table.
+[<Emit("ets:info($0, size)")>]
+let size (table: TableId<'K, 'R>) : int = nativeOnly
+
+/// Name of the table (as given to ets:new/2).
+[<Emit("ets:info($0, name)")>]
+let tableName (table: TableId<'K, 'R>) : Atom = nativeOnly
+
+/// Table type (set / ordered_set / bag / duplicate_bag).
+[<Emit("ets:info($0, type)")>]
+let tableType (table: TableId<'K, 'R>) : EtsTableType = nativeOnly
+
+/// Access level (public / protected / private).
+[<Emit("ets:info($0, protection)")>]
+let access (table: TableId<'K, 'R>) : EtsAccess = nativeOnly
+
+/// Pid of the process that owns this table.
+[<Emit("ets:info($0, owner)")>]
+let owner (table: TableId<'K, 'R>) : Pid<obj> = nativeOnly
+
+/// Number of words allocated to the table in memory.
+[<Emit("ets:info($0, memory)")>]
+let memory (table: TableId<'K, 'R>) : int = nativeOnly
+
+/// Position of the key element in each row tuple (1-based).
+[<Emit("ets:info($0, keypos)")>]
+let keypos (table: TableId<'K, 'R>) : int = nativeOnly

--- a/src/otp/Ets.fs
+++ b/src/otp/Ets.fs
@@ -60,6 +60,7 @@ type IExports =
     /// Returns the first key in the table, or None if the table is empty.
     [<Emit("(fun() -> case ets:first($0) of '$end_of_table' -> undefined; FirstKey__ -> FirstKey__ end end)()")>]
     abstract first: table: TableId<'Key, 'Row> -> 'Key option
+
     /// Returns the next key after the given key, or None if at the end.
     [<Emit("(fun() -> case ets:next($0, $1) of '$end_of_table' -> undefined; NextKey__ -> NextKey__ end end)()")>]
     abstract next: table: TableId<'Key, 'Row> * key: 'Key -> 'Key option

--- a/src/otp/GenServer.fs
+++ b/src/otp/GenServer.fs
@@ -34,18 +34,15 @@ type IExports =
     /// Starts a gen_server process.
     abstract start_link: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a named gen_server process.
-    abstract start_link:
-        name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start_link: name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a gen_server without linking.
     abstract start: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a named gen_server without linking.
-    abstract start:
-        name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start: name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Makes a synchronous call to a gen_server.
     abstract call: serverRef: ServerRef<'Call, 'Cast> * request: 'Call -> 'Reply
     /// Makes a synchronous call with timeout (int ms or atom 'infinity').
-    abstract call:
-        serverRef: ServerRef<'Call, 'Cast> * request: 'Call * timeout: U2<int, Atom> -> 'Reply
+    abstract call: serverRef: ServerRef<'Call, 'Cast> * request: 'Call * timeout: U2<int, Atom> -> 'Reply
     /// Sends an asynchronous request to a gen_server.
     abstract cast: serverRef: ServerRef<'Call, 'Cast> * request: 'Cast -> unit
     /// Sends a reply to a client that called call/2,3.
@@ -53,8 +50,7 @@ type IExports =
     /// Stops a gen_server.
     abstract stop: serverRef: ServerRef<'Call, 'Cast> -> unit
     /// Stops a gen_server with reason and timeout (int ms or atom 'infinity').
-    abstract stop:
-        serverRef: ServerRef<'Call, 'Cast> * reason: Atom * timeout: U2<int, Atom> -> unit
+    abstract stop: serverRef: ServerRef<'Call, 'Cast> * reason: Atom * timeout: U2<int, Atom> -> unit
 
 /// gen_server module
 [<ImportAll("gen_server")>]

--- a/src/otp/GenServer.fs
+++ b/src/otp/GenServer.fs
@@ -8,31 +8,53 @@ open Fable.Beam
 // fsharplint:disable MemberNames
 
 /// A gen_server reference: Pid, registered name, or {global, Name}.
+/// The phantom parameters capture the types of call/cast messages this server
+/// accepts — analogous to Gleam's Subject pattern.
 [<Erase>]
-type ServerRef = ServerRef of obj
+type ServerRef<'Call, 'Cast> = ServerRef of obj
+
+/// How a gen_server is identified when starting/registering. Erased at runtime.
+[<Erase>]
+type ServerName = ServerName of obj
+
+/// Register the gen_server locally as Name ({local, Name} tuple).
+[<Emit("{local, $0}")>]
+let localName (name: Atom) : ServerName = nativeOnly
+
+/// Register the gen_server globally as Name ({global, Name} tuple).
+[<Emit("{global, $0}")>]
+let globalName (name: Atom) : ServerName = nativeOnly
+
+/// Register the gen_server via an alternative registry ({via, Module, Name} tuple).
+[<Emit("{via, $0, $1}")>]
+let viaName (``module``: Atom) (name: Atom) : ServerName = nativeOnly
 
 [<Erase>]
 type IExports =
     /// Starts a gen_server process.
-    abstract start_link: ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    abstract start_link: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a named gen_server process.
-    abstract start_link: name: obj * ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    abstract start_link:
+        name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a gen_server without linking.
-    abstract start: ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    abstract start: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Starts a named gen_server without linking.
-    abstract start: name: obj * ``module``: Atom * args: obj * options: obj list -> Result<Pid, obj>
+    abstract start:
+        name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
     /// Makes a synchronous call to a gen_server.
-    abstract call: serverRef: ServerRef * request: obj -> obj
+    abstract call: serverRef: ServerRef<'Call, 'Cast> * request: 'Call -> 'Reply
     /// Makes a synchronous call with timeout (int ms or atom 'infinity').
-    abstract call: serverRef: ServerRef * request: obj * timeout: U2<int, Atom> -> obj
+    abstract call:
+        serverRef: ServerRef<'Call, 'Cast> * request: 'Call * timeout: U2<int, Atom> -> 'Reply
     /// Sends an asynchronous request to a gen_server.
-    abstract cast: serverRef: ServerRef * request: obj -> unit
+    abstract cast: serverRef: ServerRef<'Call, 'Cast> * request: 'Cast -> unit
     /// Sends a reply to a client that called call/2,3.
-    abstract reply: from: obj * reply: obj -> unit
+    abstract reply: from: obj * reply: 'Reply -> unit
     /// Stops a gen_server.
-    abstract stop: serverRef: ServerRef -> unit
+    abstract stop: serverRef: ServerRef<'Call, 'Cast> -> unit
     /// Stops a gen_server with reason and timeout (int ms or atom 'infinity').
-    abstract stop: serverRef: ServerRef * reason: Atom * timeout: U2<int, Atom> -> unit
+    abstract stop:
+        serverRef: ServerRef<'Call, 'Cast> * reason: Atom * timeout: U2<int, Atom> -> unit
 
 /// gen_server module
 [<ImportAll("gen_server")>]

--- a/src/otp/Io.fs
+++ b/src/otp/Io.fs
@@ -12,7 +12,7 @@ type IExports =
     /// Writes a formatted string to standard output.
     abstract format: format: string * args: obj list -> unit
     /// Writes a formatted string to a device.
-    abstract format: device: Pid * format: string * args: obj list -> unit
+    abstract format: device: Pid<'Msg> * format: string * args: obj list -> unit
     /// Reads a line from standard input (raw — returns eof atom on EOF).
     abstract get_line: prompt: string -> string
     /// Writes output to standard output.

--- a/src/otp/Lists.fs
+++ b/src/otp/Lists.fs
@@ -86,11 +86,11 @@ type IExports =
     /// Sorts a list of tuples by the Nth element (1-based).
     abstract keysort: n: int * list: BeamList<'T> -> BeamList<'T>
     /// Deletes the first tuple in List whose Nth element equals Key.
-    abstract keydelete: key: obj * n: int * list: BeamList<'T> -> BeamList<'T>
+    abstract keydelete: key: 'Key * n: int * list: BeamList<'T> -> BeamList<'T>
     /// Returns true if any tuple in List has Key at position N (1-based).
-    abstract keymember: key: obj * n: int * list: BeamList<'T> -> bool
+    abstract keymember: key: 'Key * n: int * list: BeamList<'T> -> bool
     /// Replaces the first tuple whose Nth element equals Key with NewTuple.
-    abstract keyreplace: key: obj * n: int * list: BeamList<'T> * newTuple: 'T -> BeamList<'T>
+    abstract keyreplace: key: 'Key * n: int * list: BeamList<'T> * newTuple: 'T -> BeamList<'T>
 
     /// Combines map and left fold: applies Fun to each element and an accumulator,
     /// returning a new list of the first Fun results and the final accumulator.
@@ -105,4 +105,4 @@ let lists: IExports = nativeOnly
 /// Searches a list of tuples for the first one whose Nth element (1-based) equals Key.
 /// Returns Some(tuple) if found, or None if not found.
 [<Emit("(fun() -> case lists:keyfind($0, $1, $2) of false -> undefined; KeyFindTuple__ -> KeyFindTuple__ end end)()")>]
-let keyFind (key: obj) (n: int) (list: BeamList<'T>) : 'T option = nativeOnly
+let keyFind (key: 'Key) (n: int) (list: BeamList<'T>) : 'T option = nativeOnly

--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -4,6 +4,7 @@ module Fable.Beam.Logger
 
 open Fable.Core
 open Fable.Beam
+open Fable.Beam.Maps
 
 // fsharplint:disable MemberNames
 
@@ -12,35 +13,35 @@ type IExports =
     /// Log an emergency message.
     abstract emergency: msg: string -> unit
     /// Log an emergency message with metadata or format args.
-    abstract emergency: msg: string * metadataOrArgs: obj -> unit
+    abstract emergency: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log an alert message.
     abstract alert: msg: string -> unit
     /// Log an alert message with metadata or format args.
-    abstract alert: msg: string * metadataOrArgs: obj -> unit
+    abstract alert: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log a critical message.
     abstract critical: msg: string -> unit
     /// Log a critical message with metadata or format args.
-    abstract critical: msg: string * metadataOrArgs: obj -> unit
+    abstract critical: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log an error message.
     abstract error: msg: string -> unit
     /// Log an error message with metadata or format args.
-    abstract error: msg: string * metadataOrArgs: obj -> unit
+    abstract error: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log a warning message.
     abstract warning: msg: string -> unit
     /// Log a warning message with metadata or format args.
-    abstract warning: msg: string * metadataOrArgs: obj -> unit
+    abstract warning: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log a notice message.
     abstract notice: msg: string -> unit
     /// Log a notice message with metadata or format args.
-    abstract notice: msg: string * metadataOrArgs: obj -> unit
+    abstract notice: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log an info message.
     abstract info: msg: string -> unit
     /// Log an info message with metadata or format args.
-    abstract info: msg: string * metadataOrArgs: obj -> unit
+    abstract info: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Log a debug message.
     abstract debug: msg: string -> unit
     /// Log a debug message with metadata or format args.
-    abstract debug: msg: string * metadataOrArgs: obj -> unit
+    abstract debug: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Set the primary logger configuration. Common use: set_primary_config(atom "level", atom "debug")
     abstract set_primary_config: key: Atom * value: Atom -> unit
     /// Update a handler's configuration. Common use: change formatter template.

--- a/src/otp/Rand.fs
+++ b/src/otp/Rand.fs
@@ -3,11 +3,23 @@
 module Fable.Beam.Rand
 
 open Fable.Core
+open Fable.Beam
 
 // fsharplint:disable MemberNames
 
+/// Pseudo-random number generator algorithm. These compile to Erlang atoms.
+/// See https://www.erlang.org/doc/apps/stdlib/rand#type-builtin_alg
+type RandAlg =
+    | Exsss
+    | Exro928ss
+    | Exs1024s
+    | Exsplus
+    | Exs64
+
 [<Erase>]
 type IExports =
+    /// Seeds the random number generator with the given algorithm.
+    abstract seed: alg: RandAlg -> obj
     /// Returns a random float uniformly distributed in the value range 0.0 =< X < 1.0.
     abstract uniform: unit -> float
 

--- a/src/otp/Supervisor.fs
+++ b/src/otp/Supervisor.fs
@@ -4,23 +4,24 @@ module Fable.Beam.Supervisor
 
 open Fable.Core
 open Fable.Beam
+open Fable.Beam.GenServer
 
 // fsharplint:disable MemberNames
 
 [<Erase>]
 type IExports =
     /// Starts a supervisor process.
-    abstract start_link: ``module``: Atom * args: obj -> obj
+    abstract start_link: ``module``: Atom * args: 'Args -> obj
     /// Starts a named supervisor process.
-    abstract start_link: name: obj * ``module``: Atom * args: obj -> obj
+    abstract start_link: name: ServerName * ``module``: Atom * args: 'Args -> obj
     /// Dynamically adds a child specification to a supervisor.
     abstract start_child: supRef: obj * childSpec: obj -> obj
     /// Terminates a child process.
-    abstract terminate_child: supRef: obj * id: obj -> obj
+    abstract terminate_child: supRef: obj * id: Atom -> obj
     /// Restarts a child process.
-    abstract restart_child: supRef: obj * id: obj -> obj
+    abstract restart_child: supRef: obj * id: Atom -> obj
     /// Deletes a child specification.
-    abstract delete_child: supRef: obj * id: obj -> obj
+    abstract delete_child: supRef: obj * id: Atom -> obj
     /// Returns a list of all child specifications and child processes.
     abstract which_children: supRef: obj -> obj array
     /// Returns a list with counts for each child specification.

--- a/src/otp/Timer.fs
+++ b/src/otp/Timer.fs
@@ -10,18 +10,19 @@ open Fable.Beam
 [<Erase>]
 type IExports =
     /// Sends Msg to Dest after Time milliseconds.
-    abstract send_after: time: int * dest: Pid * msg: obj -> Result<TimerRef, Atom>
+    abstract send_after: time: int * dest: Pid<'Msg> * msg: 'Msg -> Result<TimerRef<'Msg>, Atom>
     /// Sends Msg to Dest repeatedly every Time milliseconds.
-    abstract send_interval: time: int * dest: Pid * msg: obj -> Result<TimerRef, Atom>
+    abstract send_interval: time: int * dest: Pid<'Msg> * msg: 'Msg -> Result<TimerRef<'Msg>, Atom>
     /// Evaluates Fun after Time milliseconds.
-    abstract apply_after: time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef, Atom>
+    abstract apply_after:
+        time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef<'Msg>, Atom>
 
     /// Evaluates Fun repeatedly every Time milliseconds.
     abstract apply_interval:
-        time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef, Atom>
+        time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef<'Msg>, Atom>
 
     /// Cancels a previously started timer.
-    abstract cancel: timerRef: TimerRef -> Result<Atom, Atom>
+    abstract cancel: timerRef: TimerRef<'Msg> -> Result<Atom, Atom>
     /// Suspends the process for Time milliseconds.
     abstract sleep: time: int -> unit
     /// Converts hours to milliseconds.

--- a/src/otp/Timer.fs
+++ b/src/otp/Timer.fs
@@ -13,6 +13,7 @@ type IExports =
     abstract send_after: time: int * dest: Pid<'Msg> * msg: 'Msg -> Result<TimerRef<'Msg>, Atom>
     /// Sends Msg to Dest repeatedly every Time milliseconds.
     abstract send_interval: time: int * dest: Pid<'Msg> * msg: 'Msg -> Result<TimerRef<'Msg>, Atom>
+
     /// Evaluates Fun after Time milliseconds.
     abstract apply_after:
         time: int * ``module``: Atom * ``function``: Atom * args: obj list -> Result<TimerRef<'Msg>, Atom>

--- a/src/otp/Types.fs
+++ b/src/otp/Types.fs
@@ -4,17 +4,23 @@ namespace Fable.Beam
 open Fable.Core
 
 /// Erlang process identifier.
+/// The phantom parameter 'Msg captures the type of messages this process accepts —
+/// analogous to Gleam's Subject(message). Erased at runtime.
 [<Erase>]
-type Pid = Pid of obj
+type Pid<'Msg> = Pid of obj
 
 /// Erlang reference (from make_ref, monitor, etc.).
+/// The phantom parameter 'Tag identifies what the ref refers to — e.g., a
+/// monitor ref is Ref<Pid>, a request/response tag is Ref<Reply>. Erased at runtime.
 [<Erase>]
-type Ref = Ref of obj
+type Ref<'Tag> = Ref of obj
 
 /// Erlang atom.
 [<Erase>]
 type Atom = Atom of obj
 
 /// Erlang timer reference (from send_after, etc.).
+/// The phantom parameter 'Msg captures the message type that will be delivered
+/// when the timer fires — analogous to Gleam's Subject(message). Erased at runtime.
 [<Erase>]
-type TimerRef = TimerRef of obj
+type TimerRef<'Msg> = TimerRef of obj

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="TestFile.fs" />
     <Compile Include="TestLogger.fs" />
     <Compile Include="TestJsx.fs" />
+    <Compile Include="TestDynamic.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/test/TestDynamic.fs
+++ b/test/TestDynamic.fs
@@ -50,7 +50,7 @@ let ``test Decode.atom succeeds on atom`` () =
     let d: Dynamic = emitErlExpr () "ok"
 
     match Decode.atom d with
-    | Ok _ -> ()  // don't compare Atom values across the boundary, just ensure decode succeeded
+    | Ok _ -> () // don't compare Atom values across the boundary, just ensure decode succeeded
     | Error e -> failwithf "expected Ok, got Error %s" e
 #else
     ()
@@ -133,7 +133,7 @@ let ``test Decode.optional returns None for undefined`` () =
 
     match Decode.optional (System.Func<_, _> Decode.int) d with
     | Ok None -> ()
-    | Ok (Some v) -> failwithf "expected None, got Some %d" v
+    | Ok(Some v) -> failwithf "expected None, got Some %d" v
     | Error e -> failwithf "expected Ok None, got Error %s" e
 #else
     ()
@@ -145,7 +145,7 @@ let ``test Decode.optional returns Some for value`` () =
     let d: Dynamic = emitErlExpr () "42"
 
     match Decode.optional (System.Func<_, _> Decode.int) d with
-    | Ok (Some v) -> v |> equal 42
+    | Ok(Some v) -> v |> equal 42
     | Ok None -> failwith "expected Some"
     | Error e -> failwithf "expected Ok, got Error %s" e
 #else
@@ -158,7 +158,7 @@ let ``test Decode.tuple2 decodes a pair`` () =
     let d: Dynamic = emitErlExpr () "{<<\"alice\">>, 30}"
 
     match Decode.tuple2 (System.Func<_, _> Decode.string) (System.Func<_, _> Decode.int) d with
-    | Ok (name, age) ->
+    | Ok(name, age) ->
         name |> equal "alice"
         age |> equal 30
     | Error e -> failwithf "expected Ok, got Error %s" e

--- a/test/TestDynamic.fs
+++ b/test/TestDynamic.fs
@@ -1,0 +1,167 @@
+module Fable.Beam.Tests.Dynamic
+
+open Fable.Beam.Testing
+
+#if FABLE_COMPILER
+open Fable.Core
+open Fable.Core.BeamInterop
+open Fable.Beam
+#endif
+
+[<Fact>]
+let ``test Decode.int succeeds on integer`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "42"
+
+    match Decode.int d with
+    | Ok v -> v |> equal 42
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.int fails on non-integer`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "<<\"hello\">>"
+
+    match Decode.int d with
+    | Ok _ -> failwith "expected Error"
+    | Error _ -> ()
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.string succeeds on binary`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "<<\"hello\">>"
+
+    match Decode.string d with
+    | Ok v -> v |> equal "hello"
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.atom succeeds on atom`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "ok"
+
+    match Decode.atom d with
+    | Ok _ -> ()  // don't compare Atom values across the boundary, just ensure decode succeeded
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.bool succeeds on true`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "true"
+
+    match Decode.bool d with
+    | Ok v -> v |> equal true
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.field extracts map value`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "#{name => <<\"alice\">>, age => 30}"
+    let nameKey = Erlang.binaryToAtom "name"
+    let ageKey = Erlang.binaryToAtom "age"
+
+    match Decode.field nameKey (System.Func<_, _> Decode.string) d with
+    | Ok name -> name |> equal "alice"
+    | Error e -> failwithf "expected Ok name, got Error %s" e
+
+    match Decode.field ageKey (System.Func<_, _> Decode.int) d with
+    | Ok age -> age |> equal 30
+    | Error e -> failwithf "expected Ok age, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.field errors on missing key`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "#{name => <<\"alice\">>}"
+    let missingKey = Erlang.binaryToAtom "nonexistent"
+
+    match Decode.field missingKey (System.Func<_, _> Decode.string) d with
+    | Ok _ -> failwith "expected Error on missing field"
+    | Error _ -> ()
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.list decodes homogeneous list`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "[1, 2, 3, 4]"
+
+    match Decode.list (System.Func<_, _> Decode.int) d with
+    | Ok arr ->
+        Array.length arr |> equal 4
+        arr.[0] |> equal 1
+        arr.[3] |> equal 4
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.list short-circuits on first decode error`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "[1, 2, <<\"not_int\">>, 4]"
+
+    match Decode.list (System.Func<_, _> Decode.int) d with
+    | Ok _ -> failwith "expected Error"
+    | Error _ -> ()
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.optional returns None for undefined`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "undefined"
+
+    match Decode.optional (System.Func<_, _> Decode.int) d with
+    | Ok None -> ()
+    | Ok (Some v) -> failwithf "expected None, got Some %d" v
+    | Error e -> failwithf "expected Ok None, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.optional returns Some for value`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "42"
+
+    match Decode.optional (System.Func<_, _> Decode.int) d with
+    | Ok (Some v) -> v |> equal 42
+    | Ok None -> failwith "expected Some"
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Decode.tuple2 decodes a pair`` () =
+#if FABLE_COMPILER
+    let d: Dynamic = emitErlExpr () "{<<\"alice\">>, 30}"
+
+    match Decode.tuple2 (System.Func<_, _> Decode.string) (System.Func<_, _> Decode.int) d with
+    | Ok (name, age) ->
+        name |> equal "alice"
+        age |> equal 30
+    | Error e -> failwithf "expected Ok, got Error %s" e
+#else
+    ()
+#endif

--- a/test/TestErlang.fs
+++ b/test/TestErlang.fs
@@ -73,9 +73,11 @@ let ``test process dictionary get/put/erase`` () =
 #if FABLE_COMPILER
     let key = Erlang.makeRef ()
     Erlang.put key (box 42) |> ignore
+
     match Erlang.get key with
     | Some v -> v |> equal (box 42)
     | None -> failwith "process dict key should be set"
+
     Erlang.erase key |> ignore
 #else
     ()

--- a/test/TestErlang.fs
+++ b/test/TestErlang.fs
@@ -73,8 +73,9 @@ let ``test process dictionary get/put/erase`` () =
 #if FABLE_COMPILER
     let key = Erlang.makeRef ()
     Erlang.put key (box 42) |> ignore
-    let value = Erlang.get key
-    value |> equal (box 42)
+    match Erlang.get key with
+    | Some v -> v |> equal (box 42)
+    | None -> failwith "process dict key should be set"
     Erlang.erase key |> ignore
 #else
     ()

--- a/test/TestEts.fs
+++ b/test/TestEts.fs
@@ -51,3 +51,37 @@ let ``test ets tab2list`` () =
 #else
     ()
 #endif
+
+[<Fact>]
+let ``test ets typed info accessors`` () =
+#if FABLE_COMPILER
+    let table =
+        ets.new_ (Erlang.binaryToAtom "info_table", [ Erlang.binaryToAtom "set" ])
+
+    let tuple: obj = emitErlExpr () "{1, <<\"hello\">>}"
+    ets.insert (table, tuple) |> ignore
+
+    size table |> equal 1
+    tableType table |> equal Set
+    access table |> equal Protected  // default access
+    keypos table |> equal 1  // default keypos
+
+    ets.delete table
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test ets typed info with ordered_set CompiledName`` () =
+#if FABLE_COMPILER
+    let table =
+        ets.new_ (
+            Erlang.binaryToAtom "ordered_table",
+            [ Erlang.binaryToAtom "ordered_set" ]
+        )
+
+    tableType table |> equal OrderedSet
+    ets.delete table
+#else
+    ()
+#endif

--- a/test/TestEts.fs
+++ b/test/TestEts.fs
@@ -63,8 +63,8 @@ let ``test ets typed info accessors`` () =
 
     size table |> equal 1
     tableType table |> equal Set
-    access table |> equal Protected  // default access
-    keypos table |> equal 1  // default keypos
+    access table |> equal Protected // default access
+    keypos table |> equal 1 // default keypos
 
     ets.delete table
 #else
@@ -75,10 +75,7 @@ let ``test ets typed info accessors`` () =
 let ``test ets typed info with ordered_set CompiledName`` () =
 #if FABLE_COMPILER
     let table =
-        ets.new_ (
-            Erlang.binaryToAtom "ordered_table",
-            [ Erlang.binaryToAtom "ordered_set" ]
-        )
+        ets.new_ (Erlang.binaryToAtom "ordered_table", [ Erlang.binaryToAtom "ordered_set" ])
 
     tableType table |> equal OrderedSet
     ets.delete table

--- a/test/TestLogger.fs
+++ b/test/TestLogger.fs
@@ -2,6 +2,8 @@ module Fable.Beam.Tests.Logger
 
 open Fable.Beam.Testing
 
+open Fable.Core
+
 #if FABLE_COMPILER
 open Fable.Beam.Logger
 #endif
@@ -34,7 +36,7 @@ let ``test logger.debug works`` () =
 let ``test logger.info with format args`` () =
 #if FABLE_COMPILER
     // The 2-arg overload accepts both metadata maps and format args lists
-    logger.info ("test ~p message", box [ box 42 ])
+    logger.info ("test ~p message", U2.Case2 [ box 42 ])
 #else
     ()
 #endif

--- a/test/TestRand.fs
+++ b/test/TestRand.fs
@@ -5,6 +5,7 @@ open Fable.Beam.Testing
 #if FABLE_COMPILER
 open Fable.Core
 open Fable.Core.BeamInterop
+open Fable.Beam
 open Fable.Beam.Rand
 #endif
 
@@ -16,6 +17,30 @@ let ``test rand.uniform returns float in range`` () =
 #else
     ()
 #endif
+
+[<Fact>]
+let ``test rand.seed with typed algorithm DU`` () =
+#if FABLE_COMPILER
+    // Canary for StringEnum-style atom emission from F# DUs on BEAM.
+    // If DU case Exsss compiles to atom `exsss`, rand:seed/1 will accept it.
+    rand.seed Exsss |> ignore
+    let v = rand.uniform ()
+    (v >= 0.0 && v < 1.0) |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test rand.seed multi-word DU case maps to atom`` () =
+#if FABLE_COMPILER
+    // Second canary: does a multi-word case like Exro928ss produce atom exro928ss?
+    rand.seed Exro928ss |> ignore
+    let v = rand.uniform ()
+    (v >= 0.0 && v < 1.0) |> equal true
+#else
+    ()
+#endif
+
 
 [<Fact>]
 let ``test rand.uniform n returns int in range`` () =


### PR DESCRIPTION
## Summary

Systematically replaces `obj` in binding signatures with stronger types so the F# type system catches mismatches at compile time. Zero runtime impact — every change is `[<Erase>]` DUs, generic parameters, or Emit-level wrapping that compiles to identical Erlang.

## What changed

**Phantom-typed opaque handles** (Gleam `Subject(message)` analogue)
- `Pid<'Msg>`, `Ref<'Tag>`, `TimerRef<'Msg>`
- `TableId<'Key, 'Row>`, `ServerRef<'Call, 'Cast>`
- `Req` — promoted from bare `type Req = obj` alias to `[<Erase>] type Req = Req of obj`

**Erased DUs with typed Emit constructors**
- `HandlerResult<'State>` / `WsResult<'State>` for Cowboy handler returns
- `WsFrame` with `textFrame` / `binaryFrame` / `pingFrame` / `pongFrame` / `closeFrame`
- `ServerName` with `localName` / `globalName` / `viaName`

**Plain F# DUs for discrete atom sets**
Verified: DU cases without fields compile directly to Erlang atoms on Fable BEAM (lowercase first letter), with `[<CompiledName>]` handling snake_case names like `ordered_set`.
- `RandAlg` in `Rand.fs`
- `EtsTableType` (Set / OrderedSet / Bag / DuplicateBag), `EtsAccess` (Public / Protected / Private)
- Typed `ets:info/2` accessors: `size`, `tableName`, `tableType`, `access`, `owner`, `memory`, `keypos`

**`Dynamic` type + `Decode` module**
New decoder infrastructure inspired by Gleam's `gleam/dynamic/decode`. Combinators: `int` / `float` / `bool` / `atom` / `string` / `dynamic` / `field` / `list` / `optional` / `tuple2` / `succeed` / `map` / `andThen`. Uses `System.Func<>` for callbacks (matches `Lists.fs` convention, avoids a Fable positional-arg bug with curried function-valued parameters). Applied to `Erlang.binaryToTerm` and `Application.getEnv`.

**Tighter signatures across the board**
- `Erlang`: typed `send` / `exit` / `monitor` / `whereis`; `get` / `put` / `erase` for process dict as `'Value option`; `length` / `atomToList` / `listToAtom` via `BeamList`; `exactEquals : 'T -> 'T -> bool`
- `GenServer`: generic `'Args` / `'Call` / `'Cast` / `'Reply`
- `Logger`: `U2<BeamMap<Atom, obj>, obj list>` for `metadataOrArgs`
- `Application`: typed `Result` wrappers for `start` / `stop` / `ensureAllStarted`; `Dynamic option` for `getEnv`
- `Cowboy`: `Atom` listener names, `BeamMap<string, string>` headers, `Atom` for binding keys

**Structural**
- Added `Fable.Beam.Cowboy` → `Fable.Beam` project reference so Cowboy can use `Atom` / `BeamMap` / etc.
- Reordered `src/Fable.Beam.fsproj` compile order so `Maps.fs`, `Lists.fs`, `Dynamic.fs` come before modules that depend on them.

**`BINDINGS-GUIDE.md` updated**
- New "Core Rule: Avoid `obj`" section up front
- Phantom type parameter guidance on opaque handles
- DU-cases-as-atoms documentation with `[<CompiledName>]`
- `Dynamic` + `Decode` section
- `System.Func` / curried-Emit gotcha
- Anti-patterns section (bare `obj` alias, `obj list` as options bag, `obj` handler state, etc.)
- Updated decision tree and module template

## Test plan

- [x] `just test-dotnet` passes — F# compiles with no new warnings
- [x] `just test` — 283/283 pass on BEAM (267 start + 16 new: Dynamic decoders, StringEnum-via-DU canaries, ETS info accessors)
- [x] Generated Erlang inspected for key changes (`rand:seed(exsss)`, `maps:find(Key, Map)`, `ets:info(T, ordered_set)`) — confirmed zero runtime impact
- [x] `just format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)