### PR TITLE
chore: republish Fable.Beam.Jsx for Fable.Core 5.0.0 stable

### DIFF
--- a/src/jsx/Fable.Beam.Jsx.fsproj
+++ b/src/jsx/Fable.Beam.Jsx.fsproj
@@ -9,6 +9,9 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
     <PackageTags>fsharp;fable;fable-binding;fable-beam;erlang;jsx;json</PackageTags>
     <Description>Fable bindings for jsx JSON library on BEAM</Description>
+    <RepositoryUrl>https://github.com/fable-compiler/Fable.Beam</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/fable-compiler/Fable.Beam</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Jsx.fs" />


### PR DESCRIPTION
## Summary

- `Fable.Beam.Jsx 5.0.0-rc.7` is packed with `Fable.Core = [5.0.0-rc.1]`, which conflicts with `Fable.Beam >= 5.0.0-rc.25` (now on `Fable.Core >= 5.0.0` stable). Downstream consumers pulling both packages can't resolve.
- Root cause: ShipIt scopes per-package version bumps to commits touching that project's directory. The Fable.Core relaxation in #70 and the stable bump in #77 only changed root `paket.dependencies`/`paket.lock`, so Jsx was never republished.
- Fix: add `<RepositoryUrl>`, `<RepositoryType>`, `<PackageProjectUrl>` to `src/jsx/Fable.Beam.Jsx.fsproj` — useful NuGet metadata, and gives ShipIt a Jsx-scoped change to bump rc.7 → rc.8. The fresh pack picks up `Fable.Core >= 5.0.0` from the (already-relaxed) root paket files.

## Test plan

- [ ] CI green
- [ ] After merge, ShipIt opens a `chore: release` PR bumping `src/jsx/CHANGELOG.md` to 5.0.0-rc.8
- [ ] After merging the release PR, the publish workflow pushes `Fable.Beam.Jsx 5.0.0-rc.8` to NuGet with `Fable.Core (>= 5.0.0)` as the dependency
- [ ] Downstream resolves `Fable.Beam.Jsx 5.0.0-rc.8` together with the latest `Fable.Beam` / `Fable.Actor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)