### PR TITLE
fix: tighten Jsx labels binding to typed DU

### DIFF
--- a/src/jsx/Jsx.fs
+++ b/src/jsx/Jsx.fs
@@ -30,9 +30,21 @@ let stream: JsxOpt = nativeOnly
 [<Emit("uescape")>]
 let uescape: JsxOpt = nativeOnly
 
-/// Set label handling for JSON object keys (e.g., binary_to_atom).
+/// How JSON object keys are decoded. Cases compile to Erlang atoms.
+[<RequireQualifiedAccess>]
+type LabelMode =
+    /// Decode keys as UTF-8 binaries (the jsx default).
+    | Binary
+    /// Decode keys as atoms; fails if a key cannot be converted.
+    | Atom
+    /// Decode keys as existing atoms; fails if a key is not already an atom in the VM.
+    | ExistingAtom
+    /// Decode keys as atoms when possible, falling back to binaries otherwise.
+    | AttemptAtom
+
+/// Control how JSON object keys are decoded.
 [<Emit("{labels, $0}")>]
-let labels (mode: obj) : JsxOpt = nativeOnly
+let labels (mode: LabelMode) : JsxOpt = nativeOnly
 
 /// Set the number of spaces for indentation when formatting.
 [<Emit("{indent, $0}")>]

--- a/test/TestJsx.fs
+++ b/test/TestJsx.fs
@@ -3,6 +3,7 @@ module Fable.Beam.Tests.Jsx
 open Fable.Beam.Testing
 
 #if FABLE_COMPILER
+open Fable.Core
 open Fable.Beam.Jsx.Jsx
 #endif
 
@@ -83,6 +84,62 @@ let ``test jsx format with indent`` () =
     let result = jsx.format ("""{"key":"value"}""", [ indent 2 ])
     // Formatted output should be longer than minified
     (String.length result > String.length """{"key":"value"}""") |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx labels Binary keeps keys as binaries`` () =
+#if FABLE_COMPILER
+    // With LabelMode.Binary the decoded map's keys are binaries, so a binary
+    // lookup must succeed. is_json/decode round-trip is enough to prove the
+    // option was accepted by jsx (bad atoms would crash the call).
+    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.Binary ]) |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx labels Atom converts keys to atoms`` () =
+#if FABLE_COMPILER
+    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.Atom ]) |> equal true
+#else
+    ()
+#endif
+
+// Stronger probe: decode a key with LabelMode.Atom and check the resulting
+// key is an atom, not a binary. If the [<Emit>] attribute on the DU case is
+// honoured, jsx receives {labels, atom} and produces an atom key. If Fable
+// stringifies the case name, jsx receives {labels, <<"atom">>}, silently
+// ignores it, and the key stays a binary.
+[<Emit("case maps:keys($0) of [K] -> is_atom(K); _ -> false end")>]
+let private firstKeyIsAtom (m: obj) : bool = nativeOnly
+
+[<Fact>]
+let ``test jsx labels Atom probe emits raw atom option`` () =
+#if FABLE_COMPILER
+    let decoded: obj =
+        jsx.decode ("""{"atom_key_probe_xyz":"value"}""", [ labels LabelMode.Atom ])
+    firstKeyIsAtom decoded |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx labels ExistingAtom rejects unknown atoms`` () =
+#if FABLE_COMPILER
+    // Force the atom to exist before decoding.
+    let _ = "definitely_known_key_xyz"
+    jsx.is_json ("""{"definitely_known_key_xyz":"value"}""", [ labels LabelMode.ExistingAtom ])
+    |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test jsx labels AttemptAtom is accepted`` () =
+#if FABLE_COMPILER
+    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.AttemptAtom ]) |> equal true
 #else
     ()
 #endif


### PR DESCRIPTION
## Summary

- The jsx library only accepts four atoms for `{labels, _}`: `binary` (default), `atom`, `existing_atom`, `attempt_atom`. The previous binding `labels (mode: obj)` accepted any value, hiding what's legal and violating CLAUDE.md ("use concrete F# types instead of `obj` wherever possible").
- Replace with a payloadless DU `LabelMode`. Fable.Erlang compiles plain (non-erased) DU cases to **raw atoms** with automatic PascalCase→snake_case splitting — same pattern already used by `RandAlg` in `src/otp/Rand.fs:12`.

```fsharp
[<RequireQualifiedAccess>]
type LabelMode =
    | Binary | Atom | ExistingAtom | AttemptAtom

[<Emit("{labels, $0}")>]
let labels (mode: LabelMode) : JsxOpt = nativeOnly
```

Generated Erlang (verified by inspecting `build/tests/src/test_jsx.erl`):

| F# case | Erlang emitted |
| --- | --- |
| `LabelMode.Binary` | `{labels, binary}` |
| `LabelMode.Atom` | `{labels, atom}` |
| `LabelMode.ExistingAtom` | `{labels, existing_atom}` |
| `LabelMode.AttemptAtom` | `{labels, attempt_atom}` |

### Why a DU instead of four `let` helpers

An earlier iteration of this PR shipped four standalone `[<Emit>]`-bound helpers (`labelsBinary`, `labelsAtom`, ...). The DU is strictly better: same emitted Erlang, exhaustive at the call site, smaller surface, and matches the existing `RandAlg` precedent. Initial spike used `[<Erase>]` + per-case `[<Emit>]` attributes — that *broke*: erased multi-case payloadless DUs compile to camelCase **binaries** (`<<"existingAtom">>`), not atoms. Removing `[<Erase>]` is the fix.

### Side benefit

Lands a `fix:`-scoped change in `src/jsx/`, which is what ShipIt needs to bump `Fable.Beam.Jsx` from `5.0.0-rc.7` → `5.0.0-rc.8`. The previous `chore:` PR (#88) didn't trigger a bump because ShipIt's `commitsForRelease` filter (`ReleaseContext.fs:207-212`) only accepts `feat`, `perf`, `fix`, or breaking. Once this merges, ShipIt opens a release PR; merging that publishes rc.8 with the (already-relaxed) `Fable.Core >= 5.0.0` dep, unblocking downstream consumers.

**Breaking:** removes `Jsx.labels obj`. No in-repo callers; package is still pre-stable rc.

## Test plan

- [x] `just build` passes (0 warnings, 0 errors)
- [x] `just test` — all 346 tests pass on the BEAM, including:
  - 4 new `test_jsx_labels_*` tests covering each `LabelMode` case
  - `test_jsx_labels_atom_probe_emits_raw_atom_option` — decodes JSON with `LabelMode.Atom` and asserts `is_atom(K)` on the decoded key, proving Fable emits a real atom, not a binary string
- [x] Generated `.erl` inspected: each case produces a raw Erlang atom of the expected snake_case name
- [ ] CI green
- [ ] After merge, ShipIt opens a `chore: release` PR bumping `src/jsx/CHANGELOG.md` to `5.0.0-rc.8`
- [ ] Merging the release PR pushes `Fable.Beam.Jsx 5.0.0-rc.8` to NuGet with `Fable.Core (>= 5.0.0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)