### PR TITLE
chore: add NuGet and rebar3 dependency caching to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,12 +17,21 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
+          cache: true
+          cache-dependency-path: 'paket.lock'
 
       - name: Setup Erlang/OTP
         uses: erlef/setup-beam@v1
         with:
           otp-version: '27'
           rebar3-version: '3'
+
+      - name: Cache rebar3 dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-${{ hashFiles('**/rebar.config') }}
+          restore-keys: rebar3-
 
       - name: Install just
         uses: extractions/setup-just@v4


### PR DESCRIPTION
- Enable setup-dotnet NuGet caching (keyed on paket.lock) to skip
  repeated NuGet downloads on cache hits
- Add actions/cache step for rebar3's ~/.cache/rebar3 directory,
  keyed on rebar.config changes, to avoid re-downloading Hex packages
  on every CI run

These are non-breaking changes; CI continues to work even on a cache
miss (first run or after lock file changes).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
