### PR TITLE
feat: replace obj with typed APIs in Cowboy, Supervisor and GenServer bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fable": {
-      "version": "5.0.0",
+      "version": "5.1.0",
       "commands": [
         "fable"
       ],

--- a/src/cowboy/Cowboy.fs
+++ b/src/cowboy/Cowboy.fs
@@ -4,23 +4,56 @@ module Fable.Beam.Cowboy.Cowboy
 
 open Fable.Core
 open Fable.Beam
+open Fable.Beam.Cowboy.CowboyRouter
 
-/// Start a clear (HTTP) listener.
-[<Emit("cowboy:start_clear($0, $1, $2)")>]
-let startClear (name: Atom) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+// ============================================================================
+// Transport options (ranch socket options)
+// ============================================================================
 
-/// Start a TLS (HTTPS) listener.
-[<Emit("cowboy:start_tls($0, $1, $2)")>]
-let startTls (name: Atom) (transportOpts: obj) (protoOpts: obj) : obj = nativeOnly
+/// Cowboy/ranch transport options. Erased at runtime. Construct with the
+/// helpers below (more constructors can be added without breaking callers).
+[<Erase>]
+type TransportOpts = TransportOpts of obj
 
-/// Stop a running listener.
-[<Emit("cowboy:stop_listener($0)")>]
-let stopListener (name: Atom) : obj = nativeOnly
+/// Transport options listening on the given TCP port: `[{port, Port}]`.
+[<Emit("[{port, $0}]")>]
+let tcpPort (port: int) : TransportOpts = nativeOnly
 
-/// Retrieve a listener's environment value.
+// ============================================================================
+// Protocol options
+// ============================================================================
+
+/// Cowboy protocol options. Erased at runtime.
+[<Erase>]
+type ProtocolOpts = ProtocolOpts of obj
+
+/// Protocol options carrying the router dispatch table:
+/// `#{env => #{dispatch => Dispatch}}`.
+[<Emit("#{env => #{dispatch => $0}}")>]
+let protocolOpts (dispatch: Dispatch) : ProtocolOpts = nativeOnly
+
+// ============================================================================
+// Listeners
+// ============================================================================
+
+/// Start a clear (HTTP) listener. Returns the listener pid, or an error string.
+[<Emit("(fun() -> case cowboy:start_clear($0, $1, $2) of {ok, StartClearPid__} -> {ok, StartClearPid__}; {error, StartClearReason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [StartClearReason__]))} end end)()")>]
+let startClear (name: Atom) (transportOpts: TransportOpts) (protoOpts: ProtocolOpts) : Result<Pid<obj>, string> =
+    nativeOnly
+
+/// Start a TLS (HTTPS) listener. Returns the listener pid, or an error string.
+[<Emit("(fun() -> case cowboy:start_tls($0, $1, $2) of {ok, StartTlsPid__} -> {ok, StartTlsPid__}; {error, StartTlsReason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [StartTlsReason__]))} end end)()")>]
+let startTls (name: Atom) (transportOpts: TransportOpts) (protoOpts: ProtocolOpts) : Result<Pid<obj>, string> =
+    nativeOnly
+
+/// Stop a running listener. Returns Ok, or an error string if not found.
+[<Emit("(fun() -> case cowboy:stop_listener($0) of ok -> {ok, ok}; {error, StopListenerReason__} -> {error, erlang:atom_to_binary(StopListenerReason__)} end end)()")>]
+let stopListener (name: Atom) : Result<unit, string> = nativeOnly
+
+/// Retrieve a listener's environment value (dynamic — decode as needed).
 [<Emit("cowboy:get_env($0, $1)")>]
-let getEnv (name: Atom) (key: Atom) : obj = nativeOnly
+let getEnv (name: Atom) (key: Atom) : Dynamic = nativeOnly
 
 /// Update a listener's environment value.
 [<Emit("cowboy:set_env($0, $1, $2)")>]
-let setEnv (name: Atom) (key: Atom) (value: obj) : obj = nativeOnly
+let setEnv (name: Atom) (key: Atom) (value: 'V) : unit = nativeOnly

--- a/src/cowboy/CowboyReq.fs
+++ b/src/cowboy/CowboyReq.fs
@@ -31,9 +31,20 @@ let headerDefault (name: string) (req: Req) (defaultValue: string) : string = na
 [<Emit("cowboy_req:headers($0)")>]
 let headers (req: Req) : BeamMap<string, string> = nativeOnly
 
-/// Read the full request body. Returns {ok, Body, Req}.
+/// Completeness status of a `readBody` call. `Ok` means the whole body was
+/// read; `More` means it exceeded the read length and `readBody` must be called
+/// again with the returned `Req` to read the next chunk.
+[<RequireQualifiedAccess>]
+type BodyStatus =
+    | Ok
+    | More
+
+/// Read a chunk of the request body. Returns the completeness status, the chunk
+/// data (a binary), and the updated request. For bodies within the default read
+/// length this is a single `Ok` read; larger bodies yield `More` until the final
+/// `Ok`. Maps `cowboy_req:read_body/1`'s `{ok | more, Data, Req}`.
 [<Emit("cowboy_req:read_body($0)")>]
-let readBody (req: Req) : obj * byte array * Req = nativeOnly
+let readBody (req: Req) : BodyStatus * string * Req = nativeOnly
 
 /// Get the query string.
 [<Emit("cowboy_req:qs($0)")>]
@@ -47,9 +58,13 @@ let reply (status: int) (headers: BeamMap<string, string>) (body: string) (req: 
 [<Emit("cowboy_req:reply($0, $1, $2)")>]
 let replyNoBody (status: int) (headers: BeamMap<string, string>) (req: Req) : Req = nativeOnly
 
-/// Get the peer IP address and port.
-[<Emit("cowboy_req:peer($0)")>]
-let peer (req: Req) : obj * int = nativeOnly
+/// Remote peer address (as a string, e.g. "127.0.0.1") and port.
+type Peer = { Ip: string; Port: int }
+
+/// Get the remote peer address and port. The raw `inet:ip_address()` tuple is
+/// rendered to a string via `inet:ntoa/1`.
+[<Emit("(fun() -> {PeerIp__, PeerPort__} = cowboy_req:peer($0), #{ip => erlang:list_to_binary(inet:ntoa(PeerIp__)), port => PeerPort__} end)()")>]
+let peer (req: Req) : Peer = nativeOnly
 
 /// Get the scheme (<<"http">> or <<"https">>).
 [<Emit("cowboy_req:scheme($0)")>]
@@ -63,9 +78,10 @@ let host (req: Req) : string = nativeOnly
 [<Emit("cowboy_req:port($0)")>]
 let port (req: Req) : int = nativeOnly
 
-/// Parse query string into a list of key-value pairs.
-[<Emit("cowboy_req:parse_qs($0)")>]
-let parseQs (req: Req) : obj = nativeOnly
+/// Parse the query string into key-value pairs. Valueless keys (e.g. `?flag`)
+/// yield an empty-string value.
+[<Emit("(fun() -> [{ParseQsK__, case ParseQsV__ of true -> <<>>; _ -> ParseQsV__ end} || {ParseQsK__, ParseQsV__} <- cowboy_req:parse_qs($0)] end)()")>]
+let parseQs (req: Req) : (string * string) list = nativeOnly
 
 /// Get a binding value from the route.
 [<Emit("cowboy_req:binding($0, $1)")>]

--- a/src/cowboy/CowboyRouter.fs
+++ b/src/cowboy/CowboyRouter.fs
@@ -5,16 +5,40 @@ module Fable.Beam.Cowboy.CowboyRouter
 open Fable.Core
 open Fable.Beam
 
-/// Compile routing rules into a dispatch list.
-[<Emit("cowboy_router:compile($0)")>]
-let compile (routes: obj) : obj = nativeOnly
+/// A compiled Cowboy dispatch table, produced by `compile` and passed to
+/// `Cowboy.protocolOpts`. Erased at runtime.
+[<Erase>]
+type Dispatch = Dispatch of obj
 
-/// Route: {Path, Handler, InitialState}.
+/// A single route: `{Path, Handler, InitialState}`. Erased at runtime.
+[<Erase>]
+type Route = Route of obj
+
+/// A host rule pairing a host matcher with its routes. Erased at runtime.
+[<Erase>]
+type HostRule = HostRule of obj
+
+/// A host matcher: a host pattern or the wildcard `'_'`. Erased at runtime.
+[<Erase>]
+type HostMatch = HostMatch of obj
+
+/// Wildcard host matcher (`'_'`) — matches any host.
+[<Emit("'_'")>]
+let wildcard: HostMatch = nativeOnly
+
+/// Match a specific host pattern, e.g. "example.com" or ":subdomain.example.org".
+[<Emit("$0")>]
+let host (pattern: string) : HostMatch = nativeOnly
+
+/// Build a route: `{Path, Handler, InitialState}`.
 /// Handler is the module atom that implements the cowboy_handler behaviour.
 [<Emit("{$0, $1, $2}")>]
-let route (path: string) (handler: Atom) (state: 'State) : obj = nativeOnly
+let route (path: string) (handler: Atom) (state: 'State) : Route = nativeOnly
 
-/// Host rule: {HostMatch, Routes}.
-/// HostMatch is typically a binary pattern or the atom '_' for wildcard.
+/// Build a host rule pairing a host matcher with its routes.
 [<Emit("{$0, $1}")>]
-let hostRule (host: obj) (routes: obj list) : obj = nativeOnly
+let hostRule (host: HostMatch) (routes: Route list) : HostRule = nativeOnly
+
+/// Compile host rules into a dispatch table.
+[<Emit("cowboy_router:compile($0)")>]
+let compile (rules: HostRule list) : Dispatch = nativeOnly

--- a/src/otp/Application.fs
+++ b/src/otp/Application.fs
@@ -7,9 +7,9 @@ open Fable.Beam
 
 // fsharplint:disable MemberNames
 
-/// Raw low-level bindings. Prefer the typed helpers below for most use cases.
+/// Raw low-level bindings (internal escape hatch). Prefer the typed helpers below.
 [<Erase>]
-type IExports =
+type internal IExports =
     /// Starts an application and all its dependencies.
     abstract ensure_all_started: app: Atom -> obj
     /// Starts an application.
@@ -27,7 +27,7 @@ type IExports =
 
 /// application module
 [<ImportAll("application")>]
-let application: IExports = nativeOnly
+let internal application: IExports = nativeOnly
 
 // ============================================================================
 // Typed API
@@ -52,3 +52,12 @@ let start (app: Atom) : Result<unit, string> = nativeOnly
 /// Stops an application. Returns Ok on success.
 [<Emit("(fun() -> case application:stop($0) of ok -> {ok, ok}; {error, Reason__} -> {error, erlang:list_to_binary(io_lib:format(<<\"~p\">>, [Reason__]))} end end)()")>]
 let stop (app: Atom) : Result<unit, string> = nativeOnly
+
+/// Sets an application environment variable.
+[<Emit("application:set_env($0, $1, $2)")>]
+let setEnv (app: Atom) (key: Atom) (value: 'V) : unit = nativeOnly
+
+/// Returns the running applications as a dynamic list of `{Name, Description,
+/// Vsn}` tuples — decode with `Fable.Beam.Decode`.
+[<Emit("application:which_applications()")>]
+let whichApplications () : Dynamic = nativeOnly

--- a/src/otp/File.fs
+++ b/src/otp/File.fs
@@ -7,11 +7,11 @@ open Fable.Core
 // fsharplint:disable MemberNames
 
 // ============================================================================
-// Raw bindings (returns obj, caller must handle tuples)
+// Raw bindings (internal escape hatch; returns obj — prefer the typed API below)
 // ============================================================================
 
 [<Erase>]
-type IExports =
+type internal IExports =
     /// Reads the contents of a file.
     abstract read_file: filename: string -> obj
     /// Writes data to a file.
@@ -35,7 +35,7 @@ type IExports =
 
 /// file module (raw, no charlist conversion — prefer typed functions below)
 [<ImportAll("file")>]
-let file: IExports = nativeOnly
+let internal file: IExports = nativeOnly
 
 // ============================================================================
 // Typed API with charlist conversion and Result returns
@@ -82,3 +82,7 @@ let getCwd () : Result<string, string> = nativeOnly
 /// Checks if a file or directory exists at the given path.
 [<Emit("(fun() -> case file:read_file_info(binary_to_list($0)) of {ok, _} -> true; {error, _} -> false end end)()")>]
 let exists (path: string) : bool = nativeOnly
+
+/// Sets the current working directory. Handles binary_to_list conversion for path.
+[<Emit("(fun() -> case file:set_cwd(binary_to_list($0)) of ok -> {ok, ok}; {error, FileSetCwdReason__} -> {error, erlang:atom_to_binary(FileSetCwdReason__)} end end)()")>]
+let setCwd (path: string) : Result<unit, string> = nativeOnly

--- a/src/otp/GenServer.fs
+++ b/src/otp/GenServer.fs
@@ -29,16 +29,24 @@ let globalName (name: Atom) : ServerName = nativeOnly
 [<Emit("{via, $0, $1}")>]
 let viaName (``module``: Atom) (name: Atom) : ServerName = nativeOnly
 
+/// Opaque client tag passed to a `handle_call` callback and forwarded to
+/// `reply` for a deferred response. Erased at runtime.
+[<Erase>]
+type From = From of obj
+
 [<Erase>]
 type IExports =
     /// Starts a gen_server process.
-    abstract start_link: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start_link: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, Dynamic>
+
     /// Starts a named gen_server process.
-    abstract start_link: name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start_link:
+        name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, Dynamic>
+
     /// Starts a gen_server without linking.
-    abstract start: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start: ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, Dynamic>
     /// Starts a named gen_server without linking.
-    abstract start: name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, obj>
+    abstract start: name: ServerName * ``module``: Atom * args: 'Args * options: obj list -> Result<Pid<'Msg>, Dynamic>
     /// Makes a synchronous call to a gen_server.
     abstract call: serverRef: ServerRef<'Call, 'Cast> * request: 'Call -> 'Reply
     /// Makes a synchronous call with timeout (int ms or atom 'infinity').
@@ -46,7 +54,7 @@ type IExports =
     /// Sends an asynchronous request to a gen_server.
     abstract cast: serverRef: ServerRef<'Call, 'Cast> * request: 'Cast -> unit
     /// Sends a reply to a client that called call/2,3.
-    abstract reply: from: obj * reply: 'Reply -> unit
+    abstract reply: from: From * reply: 'Reply -> unit
     /// Stops a gen_server.
     abstract stop: serverRef: ServerRef<'Call, 'Cast> -> unit
     /// Stops a gen_server with reason and timeout (int ms or atom 'infinity').

--- a/src/otp/Supervisor.fs
+++ b/src/otp/Supervisor.fs
@@ -8,24 +8,88 @@ open Fable.Beam.GenServer
 
 // fsharplint:disable MemberNames
 
+// ============================================================================
+// Child specification
+// ============================================================================
+
+/// Restart strategy for a child process.
+[<RequireQualifiedAccess>]
+type Restart =
+    | [<CompiledName("permanent")>] Permanent
+    | [<CompiledName("transient")>] Transient
+    | [<CompiledName("temporary")>] Temporary
+
+/// Whether a child is a worker or a (sub)supervisor.
+[<RequireQualifiedAccess>]
+type ChildType =
+    | [<CompiledName("worker")>] Worker
+    | [<CompiledName("supervisor")>] Supervisor
+
+/// How long to wait for a child to terminate. Erased at runtime.
+[<Erase>]
+type Shutdown = Shutdown of obj
+
+/// Wait up to the given milliseconds for a graceful shutdown.
+[<Emit("$0")>]
+let shutdownTimeout (ms: int) : Shutdown = nativeOnly
+
+/// Terminate the child immediately with exit(kill).
+[<Emit("brutal_kill")>]
+let brutalKill: Shutdown = nativeOnly
+
+/// Wait indefinitely for shutdown (typically for supervisor children).
+[<Emit("infinity")>]
+let shutdownInfinity: Shutdown = nativeOnly
+
+/// A child specification (map form). `Start` is the `{Module, Function, Args}`
+/// entry point that returns `{ok, Pid}`. Compiles to an Erlang child-spec map.
+type ChildSpec =
+    { Id: Atom
+      Start: Atom * Atom * obj list
+      Restart: Restart
+      Shutdown: Shutdown
+      Type: ChildType }
+
+// ============================================================================
+// Supervisor reference
+// ============================================================================
+
+/// Reference to a running supervisor: its pid or registered name. Erased.
+[<Erase>]
+type SupRef = SupRef of obj
+
+/// Reference a supervisor by pid.
+[<Emit("$0")>]
+let fromPid (pid: Pid<obj>) : SupRef = nativeOnly
+
+/// Reference a supervisor by its locally-registered name.
+[<Emit("$0")>]
+let fromName (name: Atom) : SupRef = nativeOnly
+
+// ============================================================================
+// Bindings
+// ============================================================================
+
 [<Erase>]
 type IExports =
-    /// Starts a supervisor process.
-    abstract start_link: ``module``: Atom * args: 'Args -> obj
+    /// Starts a supervisor process. Returns the supervisor pid or an error term.
+    abstract start_link: ``module``: Atom * args: 'Args -> Result<Pid<obj>, Dynamic>
     /// Starts a named supervisor process.
-    abstract start_link: name: ServerName * ``module``: Atom * args: 'Args -> obj
-    /// Dynamically adds a child specification to a supervisor.
-    abstract start_child: supRef: obj * childSpec: obj -> obj
-    /// Terminates a child process.
-    abstract terminate_child: supRef: obj * id: Atom -> obj
-    /// Restarts a child process.
-    abstract restart_child: supRef: obj * id: Atom -> obj
-    /// Deletes a child specification.
-    abstract delete_child: supRef: obj * id: Atom -> obj
-    /// Returns a list of all child specifications and child processes.
-    abstract which_children: supRef: obj -> obj array
-    /// Returns a list with counts for each child specification.
-    abstract count_children: supRef: obj -> obj
+    abstract start_link: name: ServerName * ``module``: Atom * args: 'Args -> Result<Pid<obj>, Dynamic>
+    /// Dynamically adds and starts a child. Returns the child pid or an error term.
+    abstract start_child: supRef: SupRef * childSpec: ChildSpec -> Result<Pid<obj>, Dynamic>
+    /// Terminates a running child by id. Error is an atom (e.g. 'not_found').
+    abstract terminate_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+    /// Restarts a previously-terminated child by id. Returns the new child pid.
+    abstract restart_child: supRef: SupRef * id: Atom -> Result<Pid<obj>, Dynamic>
+    /// Deletes a child specification by id. Error is an atom (e.g. 'not_found').
+    abstract delete_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+    /// Returns the children as a dynamic list of `{Id, Child, Type, Modules}`
+    /// tuples — decode with `Fable.Beam.Decode`.
+    abstract which_children: supRef: SupRef -> Dynamic
+    /// Returns child counts as a dynamic proplist
+    /// (`specs`, `active`, `supervisors`, `workers`) — decode with `Fable.Beam.Decode`.
+    abstract count_children: supRef: SupRef -> Dynamic
 
 /// supervisor module
 [<ImportAll("supervisor")>]

--- a/test/TestFile.fs
+++ b/test/TestFile.fs
@@ -3,43 +3,7 @@ module Fable.Beam.Tests.File
 open Fable.Beam.Testing
 
 #if FABLE_COMPILER
-open Fable.Core.BeamInterop
 open Fable.Beam.File
-#endif
-
-// ============================================================================
-// Raw bindings
-// ============================================================================
-
-[<Fact>]
-let ``test file.get_cwd works`` () =
-#if FABLE_COMPILER
-    let result = file.get_cwd ()
-    // Returns {ok, Dir} tuple
-    result |> notEqual null
-#else
-    ()
-#endif
-
-[<Fact>]
-let ``test file.write_file and read_file roundtrip`` () =
-#if FABLE_COMPILER
-    let filename = "/tmp/fable_beam_test.txt"
-    file.write_file (filename, box "hello beam") |> ignore
-    let result = file.read_file filename
-    result |> notEqual null
-    file.delete filename |> ignore
-#else
-    ()
-#endif
-
-[<Fact>]
-let ``test file.list_dir works`` () =
-#if FABLE_COMPILER
-    let result = file.list_dir "/tmp"
-    result |> notEqual null
-#else
-    ()
 #endif
 
 // ============================================================================

--- a/test/TestSupervisor.fs
+++ b/test/TestSupervisor.fs
@@ -10,7 +10,8 @@ open Fable.Beam.Supervisor
 let ``test supervisor.which_children on non-existent catches error`` () =
 #if FABLE_COMPILER
     try
-        supervisor.which_children (box "nonexistent_sup_xyz") |> ignore
+        supervisor.which_children (fromName (Fable.Beam.Erlang.binaryToAtom "nonexistent_sup_xyz"))
+        |> ignore
     with _ ->
         ()
 #else


### PR DESCRIPTION
Tightens the binding surface ahead of v5.0.0 by replacing leaked `obj`
parameters and returns with precise F# types, and builds on Fable 5.1. This is
the Tier-A + Tier-B work from the `obj`-surface audit; field-validated against a
real downstream consumer (synapse), which can now drop its inline Cowboy Emits.

## Cowboy
- **`CowboyReq.readBody`** — fixes a broken binding: `obj * byte array * Req` →
  `BodyStatus * string * Req`. The `byte array` did not round-trip on BEAM; a
  binary body is a `string`, and the `{ok|more, ...}` completeness tag is now
  modelled as a `BodyStatus` DU.
- `CowboyReq.peer` → `Peer` record; `parseQs` → `(string * string) list`.
- `CowboyRouter` — typed `Dispatch`/`Route`/`HostRule`/`HostMatch` + a `wildcard`
  host helper (the `'_'` consumers were writing by hand).
- `Cowboy` — typed `TransportOpts`/`ProtocolOpts` builders, Result-returning
  `startClear`/`startTls`/`stopListener`, `Dynamic` `getEnv`, generic `setEnv`.

## Supervisor
- Typed `ChildSpec` record (+ `Restart`/`ChildType`/`Shutdown`) compiling to a
  standard OTP child-spec map, opaque `SupRef` (+ `fromPid`/`fromName`).
- Result returns; `which_children`/`count_children` → `Dynamic` (complex
  tuple/proplist returns — decode with `Fable.Beam.Decode`).

## GenServer
- `gen_server.reply` `from: obj` → opaque `From`; the four start errors
  `Result<_, obj>` → `Result<_, Dynamic>`.

## File / Application
- Mark the raw `IExports` (and `file`/`application` values) `internal` — 15
  `obj`-returning members leave the public surface. Added the missing typed
  wrappers so nothing is lost: `File.setCwd`, `Application.setEnv`,
  `Application.whichApplications`.

## Tooling
- Upgrade the Fable tool 5.0.0 → 5.1.0 (the `Fable.Core` floor stays at 5.0.0 so
  consumers aren't forced up).

## Notes
- Genuine untyped public leaks: Cowboy ~12→1, GenServer 5→0, Supervisor 8→0.
- `CowboyWebsocket.upgradeWithOpts opts: obj` intentionally left as an honest
  escape hatch (a good WS-opts builder needs a combinable form, deferred).

## Test plan
- `just test` — full F# → Erlang → BEAM pipeline, **350/350 pass** under Fable 5.1
- New Cowboy/Supervisor/GenServer codegen verified by transpiling a throwaway
  consumer and inspecting the generated Erlang (matches hand-written Emits)
- `dotnet fantomas` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
