### PR TITLE
feat: add Maps.ofList for clean literal map construction

### DIFF
--- a/src/otp/Maps.fs
+++ b/src/otp/Maps.fs
@@ -64,3 +64,11 @@ let maps: IExports = nativeOnly
 /// Type-safe wrapper around maps:find/2.
 [<Emit("(fun() -> case maps:find($0, $1) of error -> undefined; {ok, MapsFindVal__} -> MapsFindVal__ end end)()")>]
 let tryFind (key: 'K) (map: BeamMap<'K, 'V>) : 'V option = nativeOnly
+
+/// Builds a map from a list of key-value pairs. Unlike `maps.from_list` (which
+/// takes an F# array and round-trips through a process-dictionary ref via
+/// `erlang:get(fable_utils:new_ref(...))`), this takes an F# list and lowers to a
+/// direct `maps:from_list([...])` — ideal for small literal maps such as Cowboy
+/// response headers, e.g. `ofList [ "content-type", "text/html" ]`.
+[<Emit("maps:from_list($0)")>]
+let ofList (pairs: ('K * 'V) list) : BeamMap<'K, 'V> = nativeOnly

--- a/test/TestMaps.fs
+++ b/test/TestMaps.fs
@@ -120,3 +120,16 @@ let ``test tryFind returns None for missing key`` () =
 #else
     ()
 #endif
+
+[<Fact>]
+let ``test ofList builds a map from a literal list`` () =
+#if FABLE_COMPILER
+    let headers: BeamMap<string, string> =
+        ofList [ "content-type", "text/html"; "server", "cowboy" ]
+
+    maps.size headers |> equal 2
+    maps.get ("content-type", headers) |> equal "text/html"
+    tryFind "server" headers |> equal (Some "cowboy")
+#else
+    ()
+#endif


### PR DESCRIPTION
## Problem

Building a small literal map (e.g. a Cowboy response-header map for
`CowboyReq.reply`) had no clean typed option. `Maps.from_list` takes an F#
array (`('K * 'V) array`), and Fable's BEAM backend represents arrays as
process-dictionary refs, so an array literal lowers to:

```erlang
maps:from_list(erlang:get(fable_utils:new_ref([{<<"content-type">>, <<"text/html">>}])))
```

Functionally correct, but it allocates a process-dict ref on every call and
is non-idiomatic — pushing users back to inline `[<Emit("#{...}")>]` for a
basic map literal. Reported while migrating Fable.Actor's timeflies-beam
example to the typed Cowboy API (everything else migrated cleanly).

## Fix

Add `Maps.ofList : ('K * 'V) list -> BeamMap<'K, 'V>`. An F# list lowers to a
plain Erlang list, so `[<Emit("maps:from_list($0)")>]` produces a direct
`maps:from_list([{K, V}, ...])` with no ref round-trip. Consumers can now write:

```fsharp
CowboyReq.reply 200 (Maps.ofList [ "content-type", "text/html" ]) body req
```

with no `[<Emit>]`.

(The underlying array→`new_ref` lowering is a separate Fable codegen issue;
`ofList` is the binding-side fix.)

## Test plan

- `just test` — full F# → Erlang → BEAM pipeline, **351/351 pass**
- New regression test `TestMaps.fs` → `ofList builds a map from a literal list`
- Generated Erlang verified clean in `build/tests/src/test_maps.erl`:
  `maps:from_list([{<<"content-type"/utf8>>, <<"text/html"/utf8>>} | [...]])`
  — no `fable_utils:new_ref` / `erlang:get` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
