### PR TITLE
feat: add OTP logger handler bindings + fix latent bare-ok Result bug

### DIFF
--- a/BINDINGS-GUIDE.md
+++ b/BINDINGS-GUIDE.md
@@ -61,7 +61,7 @@ The only narrow places `obj` is acceptable are listed in the "When `obj` is acce
 | `int`, `float`   | `integer()`, `float()`      | Direct                                     |
 | `string`         | `binary()`                  | `<<"hello">>` — **not** charlists          |
 | `bool`           | `true` \| `false`           | Atoms                                      |
-| `unit`           | `ok`                        | Atom                                       |
+| `unit`           | `ok`                        | Atom — but `Ok ()` in a `Result` is `{ok, ok}` (see bare-`ok` anti-pattern) |
 | `tuple`          | `tuple`                     | `{A, B, C}` — direct mapping               |
 | `list<T>`        | `list()`                    | Both are linked lists                      |
 | `option<T>`      | value or `undefined`        | Erased wrapper                             |
@@ -170,7 +170,10 @@ let writeFile (path: string) (data: string) : Result<unit, string> = nativeOnly
 ```
 
 Note: for functions that return bare `ok` (not `{ok, Value}`), wrap it as
-`{ok, ok}` in the Emit so it maps to `Result<unit, string>`.
+`{ok, ok}` in the Emit so it maps to `Result<unit, string>`. **This wrapper is
+mandatory even for `[<ImportAll>]` interface members** — a plain `Result<unit, _>`
+binding over a bare-`ok` function compiles but is silently wrong at runtime. See
+the "Result over a bare-`ok` function" anti-pattern below for why.
 
 ### Records: use for structured Erlang maps
 
@@ -1006,6 +1009,44 @@ let send (pid: Pid) (msg: obj) : unit = nativeOnly
 // GOOD — types flow naturally
 let send (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
 ```
+
+### Anti-pattern: `Result<unit, _>` over a bare-`ok` function without an Emit wrapper
+
+Fable encodes `Ok ()` as the tuple `{ok, ok}` (because `unit` is the atom `ok`) and
+`Error e` as `{error, e}`. So a compiled F# `match ... with Ok () | Error _` expects
+`{ok, _}` / `{error, _}` *tuples*. But many OTP functions return a **bare `ok` atom** on
+success — `logger:add_handler/3`, `supervisor:terminate_child/2`, `file:write_file/2`, etc.
+A plain binding typed `Result<unit, _>` passes that bare `ok` straight through, where it
+matches **neither** branch:
+
+```fsharp
+// BAD — compiles, but every successful call is silently wrong at runtime.
+// OTP returns `ok`, Fable's Ok () is `{ok, ok}`, so the match falls through.
+abstract terminate_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+```
+
+This is a nasty latent bug because:
+
+- It **compiles cleanly** — the type is plausible and the codegen is valid Erlang.
+- The **error path still matches** (`{error, _}` is already in Result shape), so a test that
+  only checks the failure case passes and hides the bug. The *success* path is the one that
+  breaks.
+
+Fix: bridge `ok -> {ok, ok}` with an `[<Emit>]` wrapper. This works on abstract interface
+members too — it just overrides codegen for that one method:
+
+```fsharp
+// GOOD — wrapper converts the bare ok; Error term passes through unchanged.
+[<Emit("(fun() -> case supervisor:terminate_child($0, $1) of ok -> {ok, ok}; {error, TerminateChildReason__} -> {error, TerminateChildReason__} end end)()")>]
+abstract terminate_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+```
+
+A wrapper-free `Result` binding is correct **only** when the OTP function *already* returns
+`{ok, V} | {error, R}` (e.g. `logger:get_handler_config/1`, `gen_server:start_link/3`) —
+that shape matches Fable's `Result` representation directly, so no `[<Emit>]` is needed.
+
+**Always add a test that exercises the success (`ok`) path** of any bare-`ok` binding —
+that is the only path that reveals a missing wrapper.
 
 ## Module File Template
 

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ build:
 build-beam:
     dotnet build {{test_path}}
     {{fable}} {{test_path}} --lang Erlang --outDir {{build_path}}/tests
-    cp {{test_path}}/test_runner.erl {{test_path}}/test_counter_server.erl {{build_path}}/tests/src/
+    cp {{test_path}}/test_runner.erl {{test_path}}/test_counter_server.erl {{test_path}}/test_basic_sup.erl {{build_path}}/tests/src/
     cp {{test_path}}/rebar.config {{build_path}}/tests/rebar.config
     cd {{build_path}}/tests && rebar3 compile
 

--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -45,9 +45,22 @@ type IExports =
     /// Set the primary logger configuration. Common use: set_primary_config(atom "level", atom "debug")
     abstract set_primary_config: key: Atom * value: Atom -> unit
     /// Update a handler's configuration. Common use: change formatter template.
-    abstract update_handler_config: handler: Atom * key: Atom * value: obj -> unit
+    /// Returns ok | {error, term()} — OTP rejects some changes (e.g. changing a
+    /// logger_std_h handler's type at runtime), so the result must not be swallowed.
+    abstract update_handler_config: handler: Atom * key: Atom * value: obj -> obj
     /// Add a primary filter. The filter is an opaque {FilterFun, Extra} tuple.
     abstract add_primary_filter: id: Atom * filter: obj -> unit
+    /// Add a handler. logger:add_handler/3 — returns ok | {error, term()}.
+    /// config is an open handler-config map (e.g. logger_std_h / logger_formatter settings).
+    abstract add_handler: handlerId: Atom * modle: Atom * config: obj -> obj
+    /// Remove a handler. logger:remove_handler/1 — returns ok | {error, term()}.
+    abstract remove_handler: handlerId: Atom -> obj
+    /// Get a handler's full configuration map. logger:get_handler_config/1.
+    abstract get_handler_config: handlerId: Atom -> obj
+    /// Replace a handler's entire configuration. logger:set_handler_config/2 — returns ok | {error, term()}.
+    abstract set_handler_config: handlerId: Atom * config: obj -> obj
+    /// Set a single key in a handler's configuration. logger:set_handler_config/3 — returns ok | {error, term()}.
+    abstract set_handler_config: handlerId: Atom * key: Atom * value: obj -> obj
 
 /// logger module
 [<ImportAll("logger")>]

--- a/src/otp/Logger.fs
+++ b/src/otp/Logger.fs
@@ -44,23 +44,30 @@ type IExports =
     abstract debug: msg: string * metadataOrArgs: U2<BeamMap<Atom, obj>, obj list> -> unit
     /// Set the primary logger configuration. Common use: set_primary_config(atom "level", atom "debug")
     abstract set_primary_config: key: Atom * value: Atom -> unit
-    /// Update a handler's configuration. Common use: change formatter template.
-    /// Returns ok | {error, term()} — OTP rejects some changes (e.g. changing a
+    /// Update a single key in a handler's configuration. logger:update_handler_config/3.
+    /// Returns `Ok ()` or `Error reason` — OTP rejects some changes (e.g. changing a
     /// logger_std_h handler's type at runtime), so the result must not be swallowed.
-    abstract update_handler_config: handler: Atom * key: Atom * value: obj -> obj
+    [<Emit("(fun() -> case logger:update_handler_config($0, $1, $2) of ok -> {ok, ok}; {error, LoggerUpdateHandlerCfgReason__} -> {error, LoggerUpdateHandlerCfgReason__} end end)()")>]
+    abstract update_handler_config: handler: Atom * key: Atom * value: obj -> Result<unit, Dynamic>
     /// Add a primary filter. The filter is an opaque {FilterFun, Extra} tuple.
     abstract add_primary_filter: id: Atom * filter: obj -> unit
-    /// Add a handler. logger:add_handler/3 — returns ok | {error, term()}.
+    /// Add a handler. logger:add_handler/3. Returns `Ok ()` or `Error reason`.
     /// config is an open handler-config map (e.g. logger_std_h / logger_formatter settings).
-    abstract add_handler: handlerId: Atom * modle: Atom * config: obj -> obj
-    /// Remove a handler. logger:remove_handler/1 — returns ok | {error, term()}.
-    abstract remove_handler: handlerId: Atom -> obj
+    [<Emit("(fun() -> case logger:add_handler($0, $1, $2) of ok -> {ok, ok}; {error, LoggerAddHandlerReason__} -> {error, LoggerAddHandlerReason__} end end)()")>]
+    abstract add_handler: handlerId: Atom * modle: Atom * config: BeamMap<Atom, obj> -> Result<unit, Dynamic>
+    /// Remove a handler. logger:remove_handler/1. Returns `Ok ()` or `Error reason`.
+    [<Emit("(fun() -> case logger:remove_handler($0) of ok -> {ok, ok}; {error, LoggerRemoveHandlerReason__} -> {error, LoggerRemoveHandlerReason__} end end)()")>]
+    abstract remove_handler: handlerId: Atom -> Result<unit, Dynamic>
     /// Get a handler's full configuration map. logger:get_handler_config/1.
-    abstract get_handler_config: handlerId: Atom -> obj
-    /// Replace a handler's entire configuration. logger:set_handler_config/2 — returns ok | {error, term()}.
-    abstract set_handler_config: handlerId: Atom * config: obj -> obj
-    /// Set a single key in a handler's configuration. logger:set_handler_config/3 — returns ok | {error, term()}.
-    abstract set_handler_config: handlerId: Atom * key: Atom * value: obj -> obj
+    /// Returns `Ok config` or `Error reason` (e.g. {not_found, HandlerId}). OTP already
+    /// returns {ok, Config} | {error, term()}, which matches Fable's Result representation.
+    abstract get_handler_config: handlerId: Atom -> Result<BeamMap<Atom, obj>, Dynamic>
+    /// Replace a handler's entire configuration. logger:set_handler_config/2. Returns `Ok ()` or `Error reason`.
+    [<Emit("(fun() -> case logger:set_handler_config($0, $1) of ok -> {ok, ok}; {error, LoggerSetHandlerCfg2Reason__} -> {error, LoggerSetHandlerCfg2Reason__} end end)()")>]
+    abstract set_handler_config: handlerId: Atom * config: BeamMap<Atom, obj> -> Result<unit, Dynamic>
+    /// Set a single key in a handler's configuration. logger:set_handler_config/3. Returns `Ok ()` or `Error reason`.
+    [<Emit("(fun() -> case logger:set_handler_config($0, $1, $2) of ok -> {ok, ok}; {error, LoggerSetHandlerCfg3Reason__} -> {error, LoggerSetHandlerCfg3Reason__} end end)()")>]
+    abstract set_handler_config: handlerId: Atom * key: Atom * value: obj -> Result<unit, Dynamic>
 
 /// logger module
 [<ImportAll("logger")>]

--- a/src/otp/Supervisor.fs
+++ b/src/otp/Supervisor.fs
@@ -79,10 +79,14 @@ type IExports =
     /// Dynamically adds and starts a child. Returns the child pid or an error term.
     abstract start_child: supRef: SupRef * childSpec: ChildSpec -> Result<Pid<obj>, Dynamic>
     /// Terminates a running child by id. Error is an atom (e.g. 'not_found').
+    /// The Emit wrapper bridges OTP's bare `ok` into Fable's `{ok, ok}` Result form.
+    [<Emit("(fun() -> case supervisor:terminate_child($0, $1) of ok -> {ok, ok}; {error, SupTerminateChildReason__} -> {error, SupTerminateChildReason__} end end)()")>]
     abstract terminate_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
     /// Restarts a previously-terminated child by id. Returns the new child pid.
     abstract restart_child: supRef: SupRef * id: Atom -> Result<Pid<obj>, Dynamic>
     /// Deletes a child specification by id. Error is an atom (e.g. 'not_found').
+    /// The Emit wrapper bridges OTP's bare `ok` into Fable's `{ok, ok}` Result form.
+    [<Emit("(fun() -> case supervisor:delete_child($0, $1) of ok -> {ok, ok}; {error, SupDeleteChildReason__} -> {error, SupDeleteChildReason__} end end)()")>]
     abstract delete_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
     /// Returns the children as a dynamic list of `{Id, Child, Type, Modules}`
     /// tuples — decode with `Fable.Beam.Decode`.

--- a/test/TestLogger.fs
+++ b/test/TestLogger.fs
@@ -5,6 +5,7 @@ open Fable.Beam.Testing
 open Fable.Core
 
 #if FABLE_COMPILER
+open Fable.Beam
 open Fable.Beam.Logger
 #endif
 
@@ -37,6 +38,24 @@ let ``test logger.info with format args`` () =
 #if FABLE_COMPILER
     // The 2-arg overload accepts both metadata maps and format args lists
     logger.info ("test ~p message", U2.Case2 [ box 42 ])
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test logger add and remove handler`` () =
+#if FABLE_COMPILER
+    // Round-trip a handler through add_handler/3 and remove_handler/1, asserting the
+    // ok | {error, term()} result is returned (not swallowed).
+    let handlerId = Erlang.binaryToAtom "test_handler"
+    let modle = Erlang.binaryToAtom "logger_std_h"
+    let ok = box (Erlang.binaryToAtom "ok")
+
+    let config =
+        Maps.ofList [ (Erlang.binaryToAtom "level", box (Erlang.binaryToAtom "info")) ]
+
+    logger.add_handler (handlerId, modle, box config) |> equal ok
+    logger.remove_handler handlerId |> equal ok
 #else
     ()
 #endif

--- a/test/TestLogger.fs
+++ b/test/TestLogger.fs
@@ -6,6 +6,7 @@ open Fable.Core
 
 #if FABLE_COMPILER
 open Fable.Beam
+open Fable.Beam.Maps
 open Fable.Beam.Logger
 #endif
 
@@ -46,16 +47,15 @@ let ``test logger.info with format args`` () =
 let ``test logger add and remove handler`` () =
 #if FABLE_COMPILER
     // Round-trip a handler through add_handler/3 and remove_handler/1, asserting the
-    // ok | {error, term()} result is returned (not swallowed).
+    // ok | {error, term()} result maps to Ok () (and is not swallowed).
     let handlerId = Erlang.binaryToAtom "test_handler"
     let modle = Erlang.binaryToAtom "logger_std_h"
-    let ok = box (Erlang.binaryToAtom "ok")
 
-    let config =
+    let config: BeamMap<Atom, obj> =
         Maps.ofList [ (Erlang.binaryToAtom "level", box (Erlang.binaryToAtom "info")) ]
 
-    logger.add_handler (handlerId, modle, box config) |> equal ok
-    logger.remove_handler handlerId |> equal ok
+    logger.add_handler (handlerId, modle, config) |> equal (Ok())
+    logger.remove_handler handlerId |> equal (Ok())
 #else
     ()
 #endif

--- a/test/TestSupervisor.fs
+++ b/test/TestSupervisor.fs
@@ -3,6 +3,7 @@ module Fable.Beam.Tests.Supervisor
 open Fable.Beam.Testing
 
 #if FABLE_COMPILER
+open Fable.Beam
 open Fable.Beam.Supervisor
 #endif
 
@@ -14,6 +15,68 @@ let ``test supervisor.which_children on non-existent catches error`` () =
         |> ignore
     with _ ->
         ()
+#else
+    ()
+#endif
+
+#if FABLE_COMPILER
+// Starts a fresh test_basic_sup supervisor (one temporary `counter` child) and
+// returns a SupRef to it.
+let private startSup () : SupRef =
+    match supervisor.start_link (Erlang.binaryToAtom "test_basic_sup", []) with
+    | Ok pid -> fromPid pid
+    | Error _ -> failwith "test_basic_sup should start"
+#endif
+
+[<Fact>]
+let ``test supervisor.terminate_child succeeds for a running child`` () =
+#if FABLE_COMPILER
+    let sup = startSup ()
+
+    // Bare `ok` from OTP must surface as Ok () on the F# side.
+    match supervisor.terminate_child (sup, Erlang.binaryToAtom "counter") with
+    | Ok() -> ()
+    | Error _ -> failwith "terminate_child should succeed for a known child"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test supervisor.terminate_child returns Error not_found for unknown id`` () =
+#if FABLE_COMPILER
+    let sup = startSup ()
+
+    match supervisor.terminate_child (sup, Erlang.binaryToAtom "nope") with
+    | Ok() -> failwith "terminate_child should fail for an unknown child"
+    | Error reason -> reason |> equal (Erlang.binaryToAtom "not_found")
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test supervisor.delete_child succeeds after terminate`` () =
+#if FABLE_COMPILER
+    let sup = startSup ()
+    let counter = Erlang.binaryToAtom "counter"
+
+    // A child spec can only be deleted once the child is terminated.
+    supervisor.terminate_child (sup, counter) |> ignore
+
+    match supervisor.delete_child (sup, counter) with
+    | Ok() -> ()
+    | Error _ -> failwith "delete_child should succeed for a terminated child"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test supervisor.delete_child returns Error not_found for unknown id`` () =
+#if FABLE_COMPILER
+    let sup = startSup ()
+
+    match supervisor.delete_child (sup, Erlang.binaryToAtom "nope") with
+    | Ok() -> failwith "delete_child should fail for an unknown child"
+    | Error reason -> reason |> equal (Erlang.binaryToAtom "not_found")
 #else
     ()
 #endif

--- a/test/test_basic_sup.erl
+++ b/test/test_basic_sup.erl
@@ -1,0 +1,17 @@
+-module(test_basic_sup).
+-behaviour(supervisor).
+
+-export([init/1]).
+
+%% A minimal one_for_one supervisor with a single transient child (a
+%% test_counter_server started via gen_server). Used to exercise the
+%% supervisor:terminate_child/2 and delete_child/2 bindings. `transient`
+%% (rather than `temporary`) keeps the child spec around after
+%% terminate_child/2, so delete_child/2 can then remove it.
+init([]) ->
+    ChildSpec = #{id => counter,
+                  start => {gen_server, start_link, [test_counter_server, 0, []]},
+                  restart => transient,
+                  shutdown => 5000,
+                  type => worker},
+    {ok, {#{strategy => one_for_one}, [ChildSpec]}}.


### PR DESCRIPTION
## What

Started as: add the missing OTP `logger` handler-management bindings so downstream apps don't fall back to raw `emitErlExpr`. While doing it we found — and fixed — a latent runtime bug in the existing `Supervisor` bindings, and documented the underlying gotcha in the bindings guide.

## 1. New `logger` handler bindings (`src/otp/Logger.fs`)

Faithful 1:1 bindings for the handler-management functions ([OTP docs](https://www.erlang.org/doc/apps/kernel/logger)):

- `add_handler/3`, `remove_handler/1`, `get_handler_config/1`, `set_handler_config/2`, `set_handler_config/3`

Design:
- **Typed returns, not `obj`.** `ok | {error, term()}` → `Result<unit, Dynamic>`; `get_handler_config` → `Result<BeamMap<Atom, obj>, Dynamic>`. Matches the house convention (`File`/`Supervisor`).
- **Typed config**, not `obj`. Config params are `BeamMap<Atom, obj>` (the same typed map already used for log metadata in this file). `value` stays `obj` since handler-config values are genuinely heterogeneous.
- **Fixed `update_handler_config`'s latent bug**: it returned `unit`, silently swallowing `{error, _}` (e.g. when OTP rejects changing a `logger_std_h` handler's type at runtime). Now `Result<unit, Dynamic>`.
- Thin and unopinionated — no logging-policy helpers.

## 2. Fix: latent bare-`ok` bug in `Supervisor` (`src/otp/Supervisor.fs`)

`supervisor:terminate_child/2` and `delete_child/2` were typed `Result<unit, Atom>` but bind to OTP functions that return a **bare `ok` atom**. Fable encodes `Ok ()` as the tuple `{ok, ok}`, so a successful call matched **neither** Result branch — every success was silently wrong at runtime. (No test covered the `ok` path; the existing test only hit `which_children` on a missing supervisor.) Both now use an `[<Emit>]` `case` wrapper to bridge `ok -> {ok, ok}`, the same pattern `File`/`Logger` use.

## 3. Verification

- New `test/test_basic_sup.erl` — a `one_for_one` supervisor with a single `transient` child, wired into the `just test` pipeline (`justfile`).
- `test/TestSupervisor.fs` — 4 new tests covering **both** the `Ok ()` and `Error not_found` paths of `terminate_child` and `delete_child` (the success path is the one that exposes a missing wrapper).
- `test/TestLogger.fs` — round-trips a handler through `add_handler/3` + `remove_handler/1`, asserting `Ok ()` (only passes if the bare-`ok` bridge is correct on the BEAM).

Confirmed against OTP directly that a `temporary` child's spec is auto-removed on termination — hence the `transient` child so `delete_child` can succeed after `terminate_child`.

`just build` clean (0 warnings) · `just test` → **356/356 passing**.

Downstream apps can now write, with no `emitErlExpr`:

```fsharp
logger.remove_handler (Erlang.binaryToAtom "default") |> ignore
logger.add_handler (Erlang.binaryToAtom "default", Erlang.binaryToAtom "logger_std_h", someConfigMap) |> ignore
```

## 4. Docs (`BINDINGS-GUIDE.md`)

Documented the bare-`ok` trap as a new anti-pattern: a plain `Result<unit, _>` binding over a bare-`ok` OTP function compiles cleanly but is silently wrong at runtime, because Fable encodes `Ok ()` as `{ok, ok}` and the error path masks the bug. Includes the fix, the carve-out (no wrapper needed when OTP already returns `{ok, V} | {error, R}`), and the rule: always test the success path of a bare-`ok` binding.

## Commits

1. `feat:` add OTP logger handler-management bindings
2. `refactor:` type logger handler bindings with Result and BeamMap
3. `fix:` bridge bare ok in supervisor terminate_child/delete_child
4. `docs:` warn about Result<unit,_> over bare-ok OTP functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)