### PR TITLE
docs: correct stale Fable Emit-workaround comments

### DIFF
--- a/BINDINGS-GUIDE.md
+++ b/BINDINGS-GUIDE.md
@@ -18,7 +18,7 @@ When writing or reviewing a binding, check:
 - **Arity** — ensure all arities of a function are covered or the most common ones are bound
 - **Charlist vs binary** — the docs say `string()` for charlists; F# strings are binaries, so convert
 - **Discrete atom sets** — model as plain DUs with no fields (add `[<CompiledName>]` for snake_case atoms)
-- **Callbacks** — use `System.Func<>` / `System.Action<>` (not raw F# function types) to avoid Emit positional bugs
+- **Callbacks** — `System.Func<>` / `System.Action<>` is the house style for `ImportAll` callback params (raw F# function types also work in curried Emits — it's a consistency choice, not a correctness fix)
 
 ## Quick Reference
 
@@ -744,17 +744,23 @@ let getCwd () : Result<string, string> = nativeOnly
 
 ## IIFE Wrapping for Variable Scoping
 
-Wrap complex Emit expressions in `(fun() -> ... end)()` (an Immediately
-Invoked Function Expression). This prevents Erlang "unsafe variable"
-errors when multiple Emit calls appear in the same generated function:
+**As of Fable 5.0.0 this is handled automatically** — the Erlang backend wraps every
+`case`-containing Emit in its own `(fun() -> ... end)()`, so clause variables are isolated
+even when the same Emit is inlined twice into one function. You do **not** need to add the
+IIFE yourself, and reusing a clause variable name across bindings no longer collides.
+(Verified on 5.1.0: an un-wrapped `case` Emit called twice in one function compiles via
+`erlc` with no "unsafe variable" error and runs correctly.)
+
+Historically this required a manual Immediately Invoked Function Expression:
 
 ```fsharp
-// BAD — may cause "unsafe variable" errors in generated Erlang
+// Previously needed; now redundant — Fable adds the wrapper. Both forms generate identical
+// Erlang (Fable does not double-wrap a case Emit that already carries its own IIFE).
 [<Emit("case file:read_file($0) of {ok, Data} -> {ok, Data}; {error, R} -> {error, R} end")>]
-
-// GOOD — scoped in IIFE
-[<Emit("(fun() -> case file:read_file($0) of {ok, Data} -> {ok, Data}; {error, R} -> {error, R} end end)()")>]
 ```
+
+Existing bindings still carry manual IIFEs; they are harmless (belt-and-suspenders) and can
+be dropped opportunistically. New bindings don't need them.
 
 ## Variable Naming in Emit
 
@@ -881,41 +887,27 @@ wrappers around private Emit functions. Fable compiles cross-module
 non-Emit calls as Erlang module calls (e.g., `httpc:get/3`), which won't
 exist in the target Erlang module.
 
-### Curried Emit + function-valued param: use `System.Func`
+### Curried Emit + function-valued param: `System.Func` is optional (style, not correctness)
 
-When an Emit-bound function is **curried** AND takes a **function-valued argument**,
-Fable-BEAM can misplace positional `$N` substitutions in the generated Erlang. The symptom
-is the decoder fn appearing where another argument should be — typically manifesting as a
-runtime `{badmap, #Fun<...>}` or `badarity` error.
-
-**Fix**: wrap callback parameters as `System.Func<>` (matches the existing `Lists.fs`
-convention for `map`, `filter`, `foldl`):
+A curried `[<Emit>]` binding that takes a **function-valued argument** substitutes its
+positional `$N` **correctly** — including when an earlier `$N` is referenced after a later
+one in the body. There is no `$1`/`$2` swap. This was verified on Fable 5.1.0 for a raw
+curried `'a -> 'b` parameter:
 
 ```fsharp
-// BAD — curried signature with raw F# function type. Positional $N may be swapped.
-[<Emit("(fun() -> case maps:find($0, $2) of {ok, V__} -> $1(V__); ... end end)()")>]
+// Generates CORRECT Erlang: maps:find(Key, D) with $1 applied to the {ok, _} value.
+[<Emit("(fun() -> case maps:find($0, $2) of {ok, FieldVal__} -> $1(FieldVal__); error -> ... end end)()")>]
 let field (key: Atom) (decoder: Dynamic -> Result<'V, string>) (d: Dynamic) : Result<'V, string>
-// Generated (wrong): maps:find(Key, <decoder-fun>)   ← $1 and $2 swapped
-
-// GOOD — System.Func makes the decoder a single .NET value; substitutions are correct.
-[<Emit("(fun() -> case maps:find($0, $2) of {ok, V__} -> $1(V__); ... end end)()")>]
-let field (key: Atom) (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic)
-    : Result<'V, string>
-// Generated (correct): maps:find(Key, D)
 ```
 
-Call site: `Decode.field key (System.Func<_, _> Decode.int) d`.
+So you may use either a raw `'a -> 'b` parameter or `System.Func<>`. The `Decode` and
+`Lists` modules use `System.Func<>` purely for **stylistic consistency** (all callback-taking
+bindings look the same, and call sites read uniformly), not because a raw function type is
+broken. Pick whichever fits; don't add `System.Func` believing it's required for correctness.
 
-The alternative is to switch the whole function to **tupled args**:
-
-```fsharp
-let field (key: Atom, decoder: Dynamic -> Result<'V, string>, d: Dynamic) : Result<'V, string>
-// Call site: Decode.field (key, Decode.int, d)
-```
-
-`System.Func` is preferred when the function is a natural fit for curried partial
-application and there are multiple callbacks in the same module's API (consistency with
-`Lists.fs`).
+> Historical note: earlier revisions of this guide claimed curried Emit + raw function args
+> caused positional-substitution swaps (`{badmap, #Fun<...>}` / `badarity`). That does not
+> reproduce on Fable 5.x — the claim was stale and has been removed.
 
 ## Anti-patterns
 
@@ -1093,8 +1085,8 @@ let moduleName: IExports = nativeOnly
 // Typed API (Result return for {ok, V} | {error, R} shapes)
 // ============================================================================
 
-/// WORKAROUND: IIFE wrapping required for case expressions until Fable fixes
-/// the "unsafe variable" bug. Keep (fun() -> ... end)() around Emit cases.
+/// Note: the (fun() -> ... end)() around this case is optional as of Fable 5.0.0
+/// (the backend auto-wraps case Emits for variable scoping); shown for clarity.
 [<Emit("(fun() -> case module_name:do_something($0) of {ok, Result__} -> {ok, Result__}; {error, Reason__} -> {error, erlang:atom_to_binary(Reason__)} end end)()")>]
 let doSomething (arg: string) : Result<string, string> = nativeOnly
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,8 @@ See `BINDINGS-GUIDE.md` for the full guide. Two core patterns:
 Key rules:
 - Use concrete F# types (`int`, `string`, `Pid`, `Result<T,E>`) instead of `obj` wherever possible
 - F# strings compile to Erlang binaries (`<<"hello">>`), not charlists — use `binary_to_list($0)` when OTP expects charlists
-- Wrap complex Emit expressions in `(fun() -> ... end)()` to prevent Erlang "unsafe variable" errors
-- Use suffixed variable names in Emit (`FileReadData__`, not `Data`) to avoid Erlang variable collisions
+- `case`-containing Emit expressions are auto-wrapped in `(fun() -> ... end)()` by Fable (>= 5.0.0), so manual IIFE wrapping is no longer required (existing wrappers are harmless)
+- Suffixed Emit variable names (`FileReadData__`, not `Data`) are still good practice for non-`case` bindings, though the auto-wrap isolates `case`-clause variables
 - `[<ImportAll>]` members use tupled args; `[<Emit>]` bindings use curried args
 
 ## Architecture

--- a/src/otp/Application.fs
+++ b/src/otp/Application.fs
@@ -32,8 +32,9 @@ let internal application: IExports = nativeOnly
 // ============================================================================
 // Typed API
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Gets an application environment variable. Returns None if unset.
 /// The returned Dynamic must be decoded with `Fable.Beam.Decode` combinators.

--- a/src/otp/Binary.fs
+++ b/src/otp/Binary.fs
@@ -52,8 +52,9 @@ let binary: IExports = nativeOnly
 // ============================================================================
 // Typed API — match, matches, split, replace
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Searches for Pattern in Subject.
 /// Returns Some (startPos, length) if found, or None if not found.

--- a/src/otp/Dynamic.fs
+++ b/src/otp/Dynamic.fs
@@ -15,8 +15,9 @@ type Dynamic = Dynamic of obj
 /// Decoder combinators for extracting typed values from a `Dynamic`.
 /// Each decoder returns `Result<'T, string>` where the error is a human-readable message.
 ///
-/// WORKAROUND: Emit expressions wrapped in `(fun() -> ... end)()` to prevent
-/// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+/// Note: the `(fun() -> ... end)()` wrappers on the `case` Emits below are no longer
+/// required — Fable (>= 5.0.0) auto-wraps `case`-containing Emits for variable scoping.
+/// They're kept for explicitness and can be removed.
 module Decode =
 
     /// Decode a Dynamic as an integer.
@@ -46,8 +47,9 @@ module Decode =
 
     /// Extract a field from an Erlang map and decode it with the given decoder.
     /// Returns Error if the map doesn't contain the key or the inner decoder fails.
-    /// Uses System.Func for the decoder — matches the Lists.fs convention for
-    /// callbacks and avoids curried-arg substitution issues with Emit.
+    /// Uses System.Func for the decoder for consistency with the Lists.fs callback
+    /// convention. (A raw `Dynamic -> Result<_,_>` param also substitutes correctly
+    /// in the Emit — System.Func is a style choice here, not a correctness requirement.)
     [<Emit("(fun() -> case maps:find($0, $2) of {ok, FieldVal__} -> $1(FieldVal__); error -> {error, erlang:list_to_binary(io_lib:format(<<\"missing field ~p\">>, [$0]))} end end)()")>]
     let field (key: Atom) (decoder: System.Func<Dynamic, Result<'V, string>>) (d: Dynamic) : Result<'V, string> =
         nativeOnly

--- a/src/otp/File.fs
+++ b/src/otp/File.fs
@@ -40,10 +40,11 @@ let internal file: IExports = nativeOnly
 // ============================================================================
 // Typed API with charlist conversion and Result returns
 // ============================================================================
-// WORKAROUND: All Emit expressions below are wrapped in (fun() -> ... end)()
-// to prevent Erlang "unsafe variable" errors when multiple Emit calls appear
-// in the same function. This is a Fable BEAM backend bug — Emit inlines case
-// expressions without scoping variables. Remove IIFEs once fixed in Fable.
+// NOTE: the Emit expressions below are wrapped in (fun() -> ... end)(). As of
+// Fable 5.0.0 this is no longer required — the BEAM backend auto-wraps every
+// case-containing Emit, so clause variables are isolated even when the same Emit
+// is inlined twice into one function. The wrappers are kept for explicitness and
+// are safe to remove.
 
 /// Reads the contents of a file. Handles binary_to_list conversion for path.
 /// Returns Ok with file contents as binary, or Error with reason as string.

--- a/src/otp/Io.fs
+++ b/src/otp/Io.fs
@@ -25,8 +25,9 @@ let io: IExports = nativeOnly
 // ============================================================================
 // Typed API with eof handling
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Reads a line from standard input. Returns None on EOF (Ctrl+D),
 /// Some with the line (including trailing newline) otherwise.

--- a/src/otp/Os.fs
+++ b/src/otp/Os.fs
@@ -10,8 +10,9 @@ open Fable.Beam
 // ============================================================================
 // Environment variables
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors. Remove IIFEs once fixed in Fable.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Gets an environment variable. Returns None if not set
 /// (os:getenv returns the atom `false` when unset).

--- a/src/otp/Queue.fs
+++ b/src/otp/Queue.fs
@@ -71,8 +71,9 @@ let queue: IExports = nativeOnly
 // ============================================================================
 // Typed API — functions with non-trivial Erlang return values
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Removes the front element of queue Q.
 /// Returns (Some element, newQueue) if Q is non-empty, or (None, Q) if empty. O(1) amortized.

--- a/src/otp/String.fs
+++ b/src/otp/String.fs
@@ -84,8 +84,9 @@ let str: IExports = nativeOnly
 // ============================================================================
 // Typed API — functions with non-trivial Erlang return values
 // ============================================================================
-// WORKAROUND: Emit expressions wrapped in (fun() -> ... end)() to prevent
-// Erlang "unsafe variable" errors.
+// NOTE: the (fun() -> ... end)() wrappers on the case Emits below are no longer
+// required — Fable (>= 5.0.0) auto-wraps case-containing Emits for variable scoping.
+// Kept for explicitness; safe to remove.
 
 /// Searches for the first occurrence of SearchPattern in String, searching left to right.
 /// Returns Some suffix (the tail of String from the match start) or None if not found.


### PR DESCRIPTION
## What

Several `[<Emit>]` bindings carried workarounds (and comments) for two Fable Erlang-backend "bugs". Both were **re-verified against Fable 5.1.0 and are not real anymore** — this PR corrects the misleading justifications so future authors don't inherit phantom constraints. **No behavior change; comments/docs only.**

## The two findings (each reproduced locally before changing)

**1. Curried Emit + raw function-valued param → no `$N` swap.**
The guide claimed a curried `[<Emit>]` taking a raw `'a -> 'b` callback misplaced positional substitutions (`{badmap, #Fun<...>}`/`badarity`), and that `System.Func<>` was required to fix it. Transpiling a raw-curried `field` decoder generates correct Erlang — `maps:find(Key, D)` with `$1` applied to the `{ok, _}` value, no swap. So `System.Func<>` on callback params is a **style choice** (consistency with `Lists.fs`), not a correctness fix.

**2. `case`-Emit "unsafe variable" → fixed upstream.**
Fable ≥ 5.0.0 auto-wraps every `case`-containing Emit in its own `(fun() -> … end)()`. Transpiling an *un-wrapped* `case` Emit called twice in one function confirmed it: Fable adds the IIFE, the reused clause variable is isolated, `erlc` compiles with no "unsafe variable" error, and it runs correctly. So the manual IIFEs and `__`-suffixed clause variables are redundant.

## Changes

- `BINDINGS-GUIDE.md` — rewrote the "IIFE Wrapping" and "Curried Emit + function-valued param" sections, the template comment, and the review-checklist callback bullet.
- `CLAUDE.md` — corrected the two "key rules" about IIFE wrapping and variable suffixes.
- Per-module comments: `Dynamic`, `File`, `Io`, `String`, `Binary`, `Application`, `Os`, `Queue`.

## Deliberately *not* done

- **Did not** strip the manual IIFEs / `__` suffixes in bulk — they're harmless, and the diff is large with subtle multi-Emit edge cases.
- **Did not** switch `System.Func<>` decoder params back to raw `'a -> 'b` — that would be a **breaking API change** for callers (incl. downstream consumers), since `System.Func<_,_>` and `'a -> 'b` aren't interchangeable at call sites.

Both are noted in the comments as safe-to-simplify-later, not required.

## Verification

`just build` clean · `just test` → **356/356** (behavior-neutral). Requires Fable ≥ 5.0.0 for the auto-IIFE behavior (noted in the guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)