### PR TITLE
feat: add calendar system_time conversions + symmetric binaryToList

### DIFF
--- a/src/otp/Calendar.fs
+++ b/src/otp/Calendar.fs
@@ -7,6 +7,7 @@
 module Fable.Beam.Calendar
 
 open Fable.Core
+open Fable.Beam
 
 // fsharplint:disable MemberNames
 
@@ -63,6 +64,19 @@ type IExports =
 
     /// Converts a Gregorian second count back to ((Year,Month,Day),(Hour,Min,Sec)).
     abstract gregorian_seconds_to_datetime: seconds: int64 -> DateTime
+
+    /// Converts an OS/system time to local datetime ((Year,Month,Day),(Hour,Min,Sec)).
+    /// `time` is a system time (e.g. from `os:system_time/1` / `Os.systemTime`); `unit`
+    /// is a time unit atom such as `second`, `millisecond`, `microsecond`, `nanosecond`,
+    /// or `native` (build one with `Erlang.binaryToAtom`). Result depends on the system's
+    /// time zone configuration.
+    abstract system_time_to_local_time: time: int64 * unit: Atom -> DateTime
+
+    /// Converts an OS/system time to UTC datetime ((Year,Month,Day),(Hour,Min,Sec)).
+    /// `time` is a system time (e.g. from `os:system_time/1` / `Os.systemTime`); `unit`
+    /// is a time unit atom such as `second`, `millisecond`, `microsecond`, `nanosecond`,
+    /// or `native` (build one with `Erlang.binaryToAtom`).
+    abstract system_time_to_universal_time: time: int64 * unit: Atom -> DateTime
 
 /// calendar module
 [<ImportAll("calendar")>]

--- a/src/otp/Calendar.fs
+++ b/src/otp/Calendar.fs
@@ -66,17 +66,14 @@ type IExports =
     abstract gregorian_seconds_to_datetime: seconds: int64 -> DateTime
 
     /// Converts an OS/system time to local datetime ((Year,Month,Day),(Hour,Min,Sec)).
-    /// `time` is a system time (e.g. from `os:system_time/1` / `Os.systemTime`); `unit`
-    /// is a time unit atom such as `second`, `millisecond`, `microsecond`, `nanosecond`,
-    /// or `native` (build one with `Erlang.binaryToAtom`). Result depends on the system's
-    /// time zone configuration.
-    abstract system_time_to_local_time: time: int64 * unit: Atom -> DateTime
+    /// `time` is a system time (e.g. from `Os.systemTime`); `unit` is the matching
+    /// `TimeUnit` (e.g. `TimeUnit.Second`). Result depends on the system's time zone.
+    abstract system_time_to_local_time: time: int64 * unit: TimeUnit -> DateTime
 
     /// Converts an OS/system time to UTC datetime ((Year,Month,Day),(Hour,Min,Sec)).
-    /// `time` is a system time (e.g. from `os:system_time/1` / `Os.systemTime`); `unit`
-    /// is a time unit atom such as `second`, `millisecond`, `microsecond`, `nanosecond`,
-    /// or `native` (build one with `Erlang.binaryToAtom`).
-    abstract system_time_to_universal_time: time: int64 * unit: Atom -> DateTime
+    /// `time` is a system time (e.g. from `Os.systemTime`); `unit` is the matching
+    /// `TimeUnit` (e.g. `TimeUnit.Second`).
+    abstract system_time_to_universal_time: time: int64 * unit: TimeUnit -> DateTime
 
 /// calendar module
 [<ImportAll("calendar")>]

--- a/src/otp/Erlang.fs
+++ b/src/otp/Erlang.fs
@@ -228,6 +228,11 @@ let binaryToTerm (bin: string) : Dynamic = nativeOnly
 [<Emit("erlang:list_to_binary($0)")>]
 let listToBinary (list: BeamList<int>) : string = nativeOnly
 
+/// Convert a binary string to a list of bytes (integers in 0..255).
+/// Inverse of listToBinary. (`Binary.bin_to_list` is the equivalent in the binary module.)
+[<Emit("erlang:binary_to_list($0)")>]
+let binaryToList (bin: string) : BeamList<int> = nativeOnly
+
 /// Convert an atom to a binary string.
 [<Emit("erlang:atom_to_binary($0)")>]
 let atomToBinary (atom: Atom) : string = nativeOnly

--- a/src/otp/Erlang.fs
+++ b/src/otp/Erlang.fs
@@ -99,9 +99,10 @@ let exactEquals (a: 'T) (b: 'T) : bool = nativeOnly
 [<Emit("erlang:monotonic_time(millisecond)")>]
 let monotonicTimeMs () : int = nativeOnly
 
-/// Get system time in the given unit.
+/// Get system time in the given unit. Returns int64 — microsecond/nanosecond
+/// system time exceeds the 32-bit range.
 [<Emit("erlang:system_time($0)")>]
-let systemTime (unit: Atom) : int = nativeOnly
+let systemTime (unit: TimeUnit) : int64 = nativeOnly
 
 /// Get system time in seconds (Unix epoch).
 [<Emit("erlang:system_time(second)")>]

--- a/src/otp/Os.fs
+++ b/src/otp/Os.fs
@@ -48,9 +48,9 @@ let version () : int * int * int = nativeOnly
 // Time
 // ============================================================================
 
-/// Returns the current OS system time in the given unit (e.g., second, millisecond).
+/// Returns the current OS system time in the given unit (e.g. TimeUnit.Second).
 [<Emit("os:system_time($0)")>]
-let systemTime (unit: Atom) : int64 = nativeOnly
+let systemTime (unit: TimeUnit) : int64 = nativeOnly
 
 /// Returns the current OS system time in seconds.
 [<Emit("os:system_time(second)")>]

--- a/src/otp/Types.fs
+++ b/src/otp/Types.fs
@@ -19,6 +19,18 @@ type Ref<'Tag> = Ref of obj
 [<Erase>]
 type Atom = Atom of obj
 
+/// Erlang time unit (`erlang:time_unit()`), used by `erlang:system_time`,
+/// `os:system_time`, and `calendar:system_time_to_*`. Each case compiles to its
+/// atom (`perf_counter` via `[<CompiledName>]` for the snake_case name).
+/// Note: the rare `pos_integer()` parts-per-second form is not modelled here.
+type TimeUnit =
+    | Second
+    | Millisecond
+    | Microsecond
+    | Nanosecond
+    | Native
+    | [<CompiledName("perf_counter")>] PerfCounter
+
 /// Erlang timer reference (from send_after, etc.).
 /// The phantom parameter 'Msg captures the message type that will be delivered
 /// when the timer fires — analogous to Gleam's Subject(message). Erased at runtime.

--- a/test/TestCalendar.fs
+++ b/test/TestCalendar.fs
@@ -5,6 +5,7 @@ open Fable.Beam.Testing
 #if FABLE_COMPILER
 open Fable.Core
 open Fable.Core.BeamInterop
+open Fable.Beam
 open Fable.Beam.Calendar
 #endif
 
@@ -303,6 +304,61 @@ let ``test calendar.localTimeToUniversalTime then back roundtrips`` () =
     let utc = localTimeToUniversalTime original
     let roundtrip = universalTimeToLocalTime utc
     roundtrip |> equal original
+#else
+    ()
+#endif
+
+// ============================================================================
+// system_time_to_universal_time / system_time_to_local_time
+// ============================================================================
+
+[<Fact>]
+let ``test calendar.system_time_to_universal_time for unix epoch`` () =
+#if FABLE_COMPILER
+    // Unix epoch 0 seconds = 1970-01-01 00:00:00 UTC
+    let ((y, mo, d), (h, mi, s)) =
+        calendar.system_time_to_universal_time (0L, Erlang.binaryToAtom "second")
+
+    y |> equal 1970
+    mo |> equal 1
+    d |> equal 1
+    h |> equal 0
+    mi |> equal 0
+    s |> equal 0
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test calendar.system_time_to_universal_time for known second`` () =
+#if FABLE_COMPILER
+    // 1700000000 seconds since the Unix epoch = 2023-11-14 22:13:20 UTC
+    let ((y, mo, d), (h, mi, s)) =
+        calendar.system_time_to_universal_time (1700000000L, Erlang.binaryToAtom "second")
+
+    y |> equal 2023
+    mo |> equal 11
+    d |> equal 14
+    h |> equal 22
+    mi |> equal 13
+    s |> equal 20
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test calendar.system_time_to_local_time returns plausible datetime`` () =
+#if FABLE_COMPILER
+    // Local time depends on the system time zone, so only assert structural validity.
+    let ((y, mo, d), (h, mi, s)) =
+        calendar.system_time_to_local_time (1700000000L, Erlang.binaryToAtom "second")
+
+    (y >= 2023 && y <= 2024) |> equal true
+    (mo >= 1 && mo <= 12) |> equal true
+    (d >= 1 && d <= 31) |> equal true
+    (h >= 0 && h <= 23) |> equal true
+    (mi >= 0 && mi <= 59) |> equal true
+    (s >= 0 && s <= 60) |> equal true
 #else
     ()
 #endif

--- a/test/TestCalendar.fs
+++ b/test/TestCalendar.fs
@@ -317,7 +317,7 @@ let ``test calendar.system_time_to_universal_time for unix epoch`` () =
 #if FABLE_COMPILER
     // Unix epoch 0 seconds = 1970-01-01 00:00:00 UTC
     let ((y, mo, d), (h, mi, s)) =
-        calendar.system_time_to_universal_time (0L, Erlang.binaryToAtom "second")
+        calendar.system_time_to_universal_time (0L, TimeUnit.Second)
 
     y |> equal 1970
     mo |> equal 1
@@ -334,7 +334,7 @@ let ``test calendar.system_time_to_universal_time for known second`` () =
 #if FABLE_COMPILER
     // 1700000000 seconds since the Unix epoch = 2023-11-14 22:13:20 UTC
     let ((y, mo, d), (h, mi, s)) =
-        calendar.system_time_to_universal_time (1700000000L, Erlang.binaryToAtom "second")
+        calendar.system_time_to_universal_time (1700000000L, TimeUnit.Second)
 
     y |> equal 2023
     mo |> equal 11
@@ -351,7 +351,7 @@ let ``test calendar.system_time_to_local_time returns plausible datetime`` () =
 #if FABLE_COMPILER
     // Local time depends on the system time zone, so only assert structural validity.
     let ((y, mo, d), (h, mi, s)) =
-        calendar.system_time_to_local_time (1700000000L, Erlang.binaryToAtom "second")
+        calendar.system_time_to_local_time (1700000000L, TimeUnit.Second)
 
     (y >= 2023 && y <= 2024) |> equal true
     (mo >= 1 && mo <= 12) |> equal true

--- a/test/TestErlang.fs
+++ b/test/TestErlang.fs
@@ -314,6 +314,26 @@ let ``test atomToList returns charlist not binary`` () =
     ()
 #endif
 
+[<Fact>]
+let ``test binaryToList returns list of bytes`` () =
+#if FABLE_COMPILER
+    let bytes = Erlang.binaryToList "ABC"
+    Erlang.length bytes |> equal 3
+    Erlang.head bytes |> equal 65
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test binaryToList and listToBinary roundtrip`` () =
+#if FABLE_COMPILER
+    let original = "hello"
+    let bytes = Erlang.binaryToList original
+    Erlang.listToBinary bytes |> equal original
+#else
+    ()
+#endif
+
 
 [<Fact>]
 let ``test isEmpty returns true for empty list`` () =

--- a/test/TestOs.fs
+++ b/test/TestOs.fs
@@ -3,6 +3,7 @@ module Fable.Beam.Tests.Os
 open Fable.Beam.Testing
 
 #if FABLE_COMPILER
+open Fable.Beam
 open Fable.Beam.Os
 #endif
 
@@ -60,6 +61,18 @@ let ``test systemTimeSeconds returns positive`` () =
 #if FABLE_COMPILER
     let t = systemTimeSeconds ()
     (t > 0) |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test systemTime with TimeUnit returns a sensible value`` () =
+#if FABLE_COMPILER
+    // Exercises the TimeUnit DU: each case compiles to its time-unit atom.
+    let secs = systemTime TimeUnit.Second
+    (secs > 1_000_000_000L) |> equal true
+    let micros = systemTime TimeUnit.Microsecond
+    (micros > secs) |> equal true
 #else
     ()
 #endif


### PR DESCRIPTION
## What

Three OTP-verified binding additions plus a guide-conformance refactor of how time units are typed.

### 1. `calendar:system_time_to_local_time/2` & `system_time_to_universal_time/2` (`src/otp/Calendar.fs`)

`Calendar.fs` already binds `local_time/0`, `universal_time/0`, and the gregorian/datetime conversions — but not the two functions that convert an OS/system timestamp (e.g. `os:system_time(microsecond)`) into a datetime tuple.

- `time` is `int64` — system time in microseconds exceeds 32-bit.
- `unit` is a `TimeUnit` (see below); returns `DateTime` ↔ `datetime()`.
- Bound via `ImportAll` (tupled args); required `open Fable.Beam`.

### 2. `Erlang.binaryToList` (`src/otp/Erlang.fs`)

`erlang:binary_to_list/1` → `BeamList<int>`, the symmetric inverse of `listToBinary`. The capability existed via `Binary.bin_to_list`, but `Erlang.fs` had `listToBinary` *without* the inverse, so the obvious lookup came up empty. Doc-comment cross-references `Binary.bin_to_list`.

### 3. `TimeUnit` DU + retrofit (`src/otp/Types.fs`, `Erlang.fs`, `Os.fs`, `Calendar.fs`)

`erlang:time_unit()` is a discrete atom set, which the guide says should be a plain DU (like `RandAlg`/`EtsTableType`), not bare `Atom`. Added a shared `TimeUnit` DU (`Second`..`Native`, `PerfCounter` via `[<CompiledName>]`) in `Types.fs` and used it consistently across **all** the system-time bindings:

- `calendar:system_time_to_*` (the new bindings above)
- `erlang:system_time/1` (`Erlang.systemTime`) — also fixed its return type to `int64` (µs/ns overflow 32-bit)
- `os:system_time/1` (`Os.systemTime`)

Callers now write the compile-checked `TimeUnit.Second` instead of `Erlang.binaryToAtom "second"` (a typo was previously a silent runtime `function_clause`). The rare `pos_integer()` parts-per-second form is intentionally not modelled.

## Verification

- Signatures checked against the [stdlib/calendar](https://www.erlang.org/doc/apps/stdlib/calendar.html) and [erts/erlang](https://www.erlang.org/doc/apps/erts/erlang.html) docs.
- Generated Erlang matches OTP exactly, and `TimeUnit` cases compile to bare atoms: `calendar:system_time_to_universal_time(0, second)`, `os:system_time(microsecond)`, `erlang:binary_to_list(<<"ABC"/utf8>>)`.
- Tests: exact epoch + known-second checks for universal time, range check for local time, byte-list + roundtrip for `binaryToList`, and a `TimeUnit`-driven `Os.systemTime` check.
- **Full pipeline passes (362/362)** on the BEAM; `test-dotnet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)