### PR TITLE
chore: apply Fantomas formatting

### DIFF
--- a/src/otp/Supervisor.fs
+++ b/src/otp/Supervisor.fs
@@ -78,16 +78,20 @@ type IExports =
     abstract start_link: name: ServerName * ``module``: Atom * args: 'Args -> Result<Pid<obj>, Dynamic>
     /// Dynamically adds and starts a child. Returns the child pid or an error term.
     abstract start_child: supRef: SupRef * childSpec: ChildSpec -> Result<Pid<obj>, Dynamic>
+
     /// Terminates a running child by id. Error is an atom (e.g. 'not_found').
     /// The Emit wrapper bridges OTP's bare `ok` into Fable's `{ok, ok}` Result form.
     [<Emit("(fun() -> case supervisor:terminate_child($0, $1) of ok -> {ok, ok}; {error, SupTerminateChildReason__} -> {error, SupTerminateChildReason__} end end)()")>]
     abstract terminate_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+
     /// Restarts a previously-terminated child by id. Returns the new child pid.
     abstract restart_child: supRef: SupRef * id: Atom -> Result<Pid<obj>, Dynamic>
+
     /// Deletes a child specification by id. Error is an atom (e.g. 'not_found').
     /// The Emit wrapper bridges OTP's bare `ok` into Fable's `{ok, ok}` Result form.
     [<Emit("(fun() -> case supervisor:delete_child($0, $1) of ok -> {ok, ok}; {error, SupDeleteChildReason__} -> {error, SupDeleteChildReason__} end end)()")>]
     abstract delete_child: supRef: SupRef * id: Atom -> Result<unit, Atom>
+
     /// Returns the children as a dynamic list of `{Id, Child, Type, Modules}`
     /// tuples — decode with `Fable.Beam.Decode`.
     abstract which_children: supRef: SupRef -> Dynamic

--- a/test/TestJsx.fs
+++ b/test/TestJsx.fs
@@ -120,6 +120,7 @@ let ``test jsx labels Atom probe emits raw atom option`` () =
 #if FABLE_COMPILER
     let decoded: obj =
         jsx.decode ("""{"atom_key_probe_xyz":"value"}""", [ labels LabelMode.Atom ])
+
     firstKeyIsAtom decoded |> equal true
 #else
     ()
@@ -130,6 +131,7 @@ let ``test jsx labels ExistingAtom rejects unknown atoms`` () =
 #if FABLE_COMPILER
     // Force the atom to exist before decoding.
     let _ = "definitely_known_key_xyz"
+
     jsx.is_json ("""{"definitely_known_key_xyz":"value"}""", [ labels LabelMode.ExistingAtom ])
     |> equal true
 #else
@@ -139,7 +141,8 @@ let ``test jsx labels ExistingAtom rejects unknown atoms`` () =
 [<Fact>]
 let ``test jsx labels AttemptAtom is accepted`` () =
 #if FABLE_COMPILER
-    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.AttemptAtom ]) |> equal true
+    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.AttemptAtom ])
+    |> equal true
 #else
     ()
 #endif

--- a/test/TestUriString.fs
+++ b/test/TestUriString.fs
@@ -93,7 +93,8 @@ let ``test normalize removes default http port`` () =
 [<Fact>]
 let ``test normalize removes default https port`` () =
 #if FABLE_COMPILER
-    normalize "https://example.com:443/path" |> equal (Ok "https://example.com/path")
+    normalize "https://example.com:443/path"
+    |> equal (Ok "https://example.com/path")
 #else
     ()
 #endif
@@ -113,7 +114,8 @@ let ``test normalize resolves dot segments`` () =
 [<Fact>]
 let ``test resolve absolute path reference`` () =
 #if FABLE_COMPILER
-    resolve "/new" "https://example.com/old/page" |> equal (Ok "https://example.com/new")
+    resolve "/new" "https://example.com/old/page"
+    |> equal (Ok "https://example.com/new")
 #else
     ()
 #endif
@@ -121,7 +123,8 @@ let ``test resolve absolute path reference`` () =
 [<Fact>]
 let ``test resolve relative path reference`` () =
 #if FABLE_COMPILER
-    resolve "new" "https://example.com/old/page" |> equal (Ok "https://example.com/old/new")
+    resolve "new" "https://example.com/old/page"
+    |> equal (Ok "https://example.com/old/new")
 #else
     ()
 #endif


### PR DESCRIPTION
## Summary

Applies pending Fantomas formatting to three files that had drifted from the project style. Pure whitespace/formatting — no behavioral changes.

- `src/otp/Supervisor.fs` — blank lines between interface members
- `test/TestJsx.fs` — blank line after multi-line bindings; wrap a long pipe
- `test/TestUriString.fs` — wrap long pipe expressions

Produced by `just format` (`dotnet fantomas src` + `dotnet fantomas test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)