### PR TITLE
docs: add Ecosystem section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ BEAM backend. This package provides typed bindings for
 Erlang/OTP standard modules so you can call them directly
 from F#.
 
+## Ecosystem
+
+Libraries built on top of Fable.Beam:
+
+| Library | Description |
+| --- | --- |
+| [Fable.Actor](https://github.com/fable-hub/Fable.Actor) | F# actor model for Fable and the BEAM |
+| [Fable.Logging](https://github.com/fable-hub/Fable.Logging) | Logging framework for Fable |
+| [Fable.Reactive](https://github.com/fable-hub/Fable.Reactive) | Async reactive (Rx) programming for F# and Fable |
+| [Fable.TypedJson](https://github.com/dbrattli/Fable.TypedJson) | Pydantic-flavored JSON validation and serialization for F# records |
+
 ## Packages
 
 | Package | Description |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Libraries built on top of Fable.Beam:
 | --- | --- |
 | [Fable.Actor](https://github.com/fable-hub/Fable.Actor) | F# actor model for Fable and the BEAM |
 | [Fable.Logging](https://github.com/fable-hub/Fable.Logging) | Logging framework for Fable |
-| [Fable.Reactive](https://github.com/fable-hub/Fable.Reactive) | Async reactive (Rx) programming for F# and Fable |
 | [Fable.TypedJson](https://github.com/dbrattli/Fable.TypedJson) | Pydantic-flavored JSON validation and serialization for F# records |
 
 ## Packages


### PR DESCRIPTION
## Summary

Adds an **Ecosystem** section near the top of the README listing libraries built on top of Fable.Beam, to highlight the surrounding ecosystem and lend credibility to the project.

| Library | Description |
| --- | --- |
| [Fable.Actor](https://github.com/fable-hub/Fable.Actor) | F# actor model for Fable and the BEAM |
| [Fable.Logging](https://github.com/fable-hub/Fable.Logging) | Logging framework for Fable |
| [Fable.Reactive](https://github.com/fable-hub/Fable.Reactive) | Async reactive (Rx) programming for F# and Fable |
| [Fable.TypedJson](https://github.com/dbrattli/Fable.TypedJson) | Pydantic-flavored JSON validation and serialization for F# records |

🤖 Generated with [Claude Code](https://claude.com/claude-code)