### PR TITLE
fix!: upgrade to Fable 5.11 and fix chardata handling in string bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fable": {
-      "version": "5.8.1",
+      "version": "5.11.0",
       "commands": [
         "fable"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fable": {
-      "version": "5.6.0",
+      "version": "5.8.1",
       "commands": [
         "fable"
       ],

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ build/
 # Paket
 paket-files/
 
+# Fable BEAM/Erlang spike output (transpiled .erl + rebar3 build)
+beam-build/
+
 # Claude
 .claude/worktrees

--- a/BROKEN-BINDINGS.md
+++ b/BROKEN-BINDINGS.md
@@ -28,6 +28,13 @@ The split turned out to be instructive: **8 were broken bindings, 6 were broken 
 assertions could actually fail, the tests got checked for the first time too — and a third of them
 were asserting the wrong thing. A test that can't fail is not a weaker test; it's not a test.
 
+**A 7th bad test surfaced later, on CI only.** `binary.referenced_byte_size` was asserted to equal 5
+for `"hello"` — but that function reports the size of the *underlying* memory, which OTP's own docs
+call "a hint for optimization, not exact." It returned 5 on the OTP 25 dev box and 40 on CI's OTP 27
+(and 256 for a shell literal). There is no portable value; the test now asserts the only invariant
+the function guarantees, `referenced_byte_size s >= byte_size s >= 0`. Lesson: a green suite on one
+OTP release is not a green suite — assert invariants, not implementation-defined constants.
+
 ### How could these ever have "worked"?
 
 They didn't — nothing verified them. But they *looked* fine for a second reason worth remembering:

--- a/BROKEN-BINDINGS.md
+++ b/BROKEN-BINDINGS.md
@@ -1,0 +1,139 @@
+# 14 broken bindings, previously hidden by a no-op test suite
+
+## How these surfaced
+
+Until the Fable 5.8.1 upgrade, **`equal` never raised**, so no assertion in this repo could fail.
+`Fable.Beam.Testing.equal` delegates to `Fable.Core.Testing.Assert.AreEqual`, and Fable's BEAM
+backend lowered that to a bare *equality expression* whose boolean result was discarded:
+
+```erlang
+equal(Expected, Actual) ->
+    fable_comparison:equals(Actual, Expected).   %% returns false; never raises
+```
+
+```
+1> testing:equal(1, 2).
+false
+```
+
+The suite reported **367/367 passing** while only ever catching outright crashes — never a wrong
+value. Fixed upstream in `../Fable` (see `BEAM-ASSERT-AND-ERASED-REFLECTION-PROMPT.md` there);
+with real assertions the same suite reports **353 passed, 14 failed**.
+
+None of them are Fable bugs.
+
+**Status: all 14 are fixed — the suite is 367 passed, 0 failed, and this time the green is real.**
+
+The split turned out to be instructive: **8 were broken bindings, 6 were broken tests.** Once
+assertions could actually fail, the tests got checked for the first time too — and a third of them
+were asserting the wrong thing. A test that can't fail is not a weaker test; it's not a test.
+
+### How could these ever have "worked"?
+
+They didn't — nothing verified them. But they *looked* fine for a second reason worth remembering:
+an iolist is still valid Erlang chardata. Hand `string:pad`'s result straight to `io:format`,
+`file:write` or a Cowboy body and OTP flattens it for you, producing exactly the bytes you expected.
+It only bites when the value is **compared, pattern-matched, or stored as a binary** — which is
+exactly what a test does, and exactly what the F# type claims you're holding.
+
+## The bugs
+
+Most are the same root cause, and it's the one `CLAUDE.md` already warns about: **F# strings are
+Erlang binaries**, but several OTP functions return an *iolist* or a *charlist*. The bindings type
+them as `string` and hand the raw result straight back, so the value is structurally wrong even
+though it prints plausibly.
+
+| # | Test | Expected | Actual | Cause |
+|---|---|---|---|---|
+| 1 | `string.replace_all` | `<<"XXbbXX">>` | `[<<>>,<<"XX">>,<<"bb">>,<<"XX">>,<<>>]` | `string:replace/4` returns an iolist |
+| 2 | `string.replace_first` | `<<"XXbbaa">>` | `[<<>>,<<"XX">>,<<"bbaa">>]` | same |
+| 3 | `str.pad_leading_with_direction` | `<<"   hi">>` | `["   ",<<"hi">>]` | `string:pad/4` returns an iolist |
+| 4 | `str.pad_trailing_to_length` | `<<"hi   ">>` | `[<<"hi">>,32,32,32]` | same |
+| 5 | `str.pad_with_custom_character` | `<<"007">>` | `[[<<"0">>,<<"0">>],<<"7">>]` | same |
+| 6 | `str.reverse` | `<<"olleh">>` | `"olleh"` (charlist) | `string:reverse/1` returns a charlist |
+| 7 | `to_graphemes` | `<<"a">>` | `97` | `string:to_graphemes/1` returns codepoints, not binaries |
+| 8 | `uri_string.compose_query` empty list | `<<>>` | `[]` | empty iolist not normalised |
+| 9 | `binary.longest_common_prefix` | `4` | `3` | **bad test** — 3 is correct |
+| 10 | `erlang.send_and_receive` | `0` | `1` | **bad test** — sent the wrong message shape |
+| 11–14 | `jsx.labels_*` (atom, attempt_atom, binary, existing_atom) | `true` | `false` | **bad tests** — `is_json` can't observe `labels` |
+
+### Fix for 1–8 (done)
+
+Every result is flattened at the binding boundary with `unicode:characters_to_binary/1` — chosen over
+`iolist_to_binary/1` because it also handles charlists and codepoints above 255, which
+`string:reverse` and a non-ASCII `pad` character produce:
+
+```fsharp
+[<Emit("unicode:characters_to_binary(string:replace($0, $1, $2, all))")>]
+let replaceAll (s: string) (pattern: string) (replacement: string) : string = nativeOnly
+```
+
+`toGraphemes` (#7) needed each *cluster* converted, not just the outer list, since
+`string:to_graphemes` yields codepoints (`97`) or codepoint lists:
+
+```fsharp
+[<Emit("fable_utils:new_ref([unicode:characters_to_binary([StringGrapheme__]) || StringGrapheme__ <- string:to_graphemes($0)])")>]
+```
+
+**API change:** `reverse` and the three `pad` arities could not be fixed in place. They were
+`abstract` members on the `[<ImportAll("string")>]` interface, which emits `string:pad(S, N)`
+directly — there is nowhere to wrap the result. They are now module-level `Emit` bindings, so the
+call sites move and the overloads become distinct names (module-level F# functions can't overload):
+
+| Was | Now |
+|---|---|
+| `str.reverse s` | `reverse s` |
+| `str.pad (s, n)` | `pad s n` |
+| `str.pad (s, n, dir)` | `padDir s n dir` |
+| `str.pad (s, n, dir, ch)` | `padWith s n dir ch` |
+
+The old interface members are left in `String.fs` as commented-out stubs explaining why.
+
+### Fix for 9–14 (done) — every one of these was a bad *test*, not a bad binding
+
+Reproducing each by hand in `erl` first was the right call: all six bindings were correct.
+
+- **#9 `longest_common_prefix`.** `binary:longest_common_prefix([<<"foobar">>,<<"foobaz">>,<<"fooqux">>])`
+  really is `3` — `"foo"` is the prefix common to *all three*; only the first two share `"fooba"`.
+  The test asserted 4. Fixed the expectation.
+
+- **#10 `send_and_receive`.** A nullary DU case compiles to a **bare atom** (`ping`); only a case
+  *with* fields becomes a tagged tuple (`Data 42` → `{data, 42}`). The test sent the 1-tuple
+  `{ping}`, which never matched the generated receive clause — so it silently sat out the full
+  1000 ms timeout and took the `None` branch. Now sends `ping`. (This one was also costing a
+  wall-clock second per run.)
+
+- **#11–14 `jsx labels`.** `labels` is a **decoder** option. `jsx:is_json/2` does not accept it and
+  simply answers `false`:
+  ```erlang
+  1> jsx:is_json(<<"{\"key\":\"value\"}">>, [{labels, atom}]).
+  false
+  2> jsx:is_json(<<"{\"key\":\"value\"}">>, []).
+  true
+  ```
+  So `is_json` could never demonstrate that the option took effect — the tests' own premise
+  ("is_json is enough to prove the option was accepted") was false. Tellingly, the one test in the
+  group that used `decode` and inspected the key type *passed all along*. The four now decode and
+  assert on the resulting keys, and `ExistingAtom` asserts the badarg rejection that gives it its
+  name.
+
+The `labels` binding itself was fine throughout: Fable emits the raw atom `{labels, atom}`, not
+`{labels, <<"atom">>}` — which is exactly what the surviving probe test was written to catch.
+
+## Why this happened, and what stops it recurring
+
+Two independent failure modes conspired, and *both* reported success:
+
+1. Assertions could not fail (fixed upstream in Fable).
+2. Fable 5.8.1 renamed generated modules (`test_maps` → `fable_beam_test_test_maps`), which broke
+   `test_runner.erl`'s `lists:prefix("test_", ...)` discovery. The runner then found **zero** tests
+   and printed *"All tests passed!"*.
+
+`test/test_runner.erl` now discovers tests by **exports** (any module exporting `test_*/0`) rather
+than by module name, and **refuses to report success on an empty suite**. That empty-suite guard is
+the cheap insurance: a discovery bug can now never again look like a green build.
+
+The longer-term answer is the Scriptorium spike (`spike/scriptorium`, `just spike`): Nib's assertions
+raise from F# itself and don't depend on the backend lowering `Assert.AreEqual`, and Quill registers
+tests explicitly instead of rediscovering them by naming convention — so neither failure mode is
+expressible.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ test_path := "test"
 # Development mode: use local Fable repo instead of dotnet tool
 # Usage: just dev=true test
 dev := "false"
-fable_repo := justfile_directory() / "../fable"
+fable_repo := justfile_directory() / "../Fable"
 fable := if dev == "true" { "dotnet run --project " + fable_repo / "src/Fable.Cli" + " --" } else { "dotnet fable" }
 
 # Default recipe - show available commands
@@ -55,6 +55,17 @@ test: build-beam
 test-dotnet:
     dotnet build {{test_path}}
     dotnet run --project {{test_path}}
+
+# Spike: run the Scriptorium test framework (Nib + Quill) on the BEAM.
+# No test_runner.erl and no [<Fact>]: Quill's runner is the [<EntryPoint>], which Fable emits as
+# main:main/1. It halts the VM with the suite's exit code, so a failing test fails this recipe.
+spike:
+    dotnet build spike/scriptorium
+    {{fable}} spike/scriptorium --lang beam -o spike/scriptorium/beam-build
+    cd spike/scriptorium/beam-build && rebar3 compile
+    @echo ""
+    cd spike/scriptorium/beam-build && \
+        ERL_LIBS="$(pwd)/_build/default/lib" erl -noshell -eval 'main:main([])' -s init stop
 
 # Create NuGet packages with versions from changelogs
 pack:

--- a/spike/scriptorium/Main.fs
+++ b/spike/scriptorium/Main.fs
@@ -1,0 +1,77 @@
+module Main
+
+open Scriptorium.Nib.Assertion
+open type Scriptorium.Quill.Test
+open type Scriptorium.Quill.Runner
+
+open Fable.Beam.Maps
+
+/// Spike: run the Scriptorium test framework (Nib assertions + the Quill runner) on the BEAM,
+/// against real Fable.Beam bindings.
+///
+/// Unlike test/, there is no Erlang test_runner.erl and no [<Fact>] marker: Quill's runner *is*
+/// the entry point. Fable emits [<EntryPoint>] as main:main/1, Quill runs the suite and halts the
+/// VM with the exit code, so `erl` returns non-zero on failure.
+let tests =
+    [ testList (
+          "Nib assertions on the BEAM",
+          [ test ("isEqualTo", fun _ -> assertThat 42 (isEqualTo 42))
+
+            test ("chained comparisons", fun _ -> assertThat 42 (isGreaterThan 40 >> isLessThan 50))
+
+            // F# strings compile to Erlang binaries (<<"hello">>), not charlists.
+            test ("strings", fun _ -> assertThat "hello" (isEqualTo "hello"))
+
+            test ("booleans", fun _ -> assertThat true isTrue)
+
+            test ("lists", fun _ -> assertThat [ 1; 2; 3 ] (hasSize 3 >> contain 2))
+
+            // Structural equality across the Fable runtime, not just primitives.
+            test ("options", fun _ -> assertThat (Some "cowboy") (isEqualTo (Some "cowboy"))) ]
+      )
+
+      testList (
+          "Fable.Beam maps bindings",
+          [ test (
+                "maps.new_ creates an empty map",
+                fun _ ->
+                    let m: BeamMap<string, int> = maps.new_ ()
+                    assertThat (maps.size m) (isEqualTo 0)
+            )
+
+            test (
+                "maps.put and maps.get round-trip",
+                fun _ ->
+                    let m: BeamMap<string, string> = maps.new_ ()
+                    let m = maps.put ("key", "value", m)
+                    assertThat (maps.get ("key", m)) (isEqualTo "value")
+            )
+
+            test (
+                "maps.get falls back to the default for a missing key",
+                fun _ ->
+                    let m: BeamMap<string, int> = maps.new_ ()
+                    assertThat (maps.get ("missing", m, 42)) (isEqualTo 42)
+            )
+
+            test (
+                "tryFind maps presence onto an option",
+                fun _ ->
+                    let m: BeamMap<string, int> = maps.put ("x", 99, maps.new_ ())
+                    assertThat (tryFind "x" m) (isEqualTo (Some 99))
+                    assertThat (tryFind "nope" m) (isEqualTo None)
+            )
+
+            test (
+                "ofList builds a map from a literal list",
+                fun _ ->
+                    let headers: BeamMap<string, string> =
+                        ofList [ "content-type", "text/html"; "server", "cowboy" ]
+
+                    assertThat (maps.size headers) (isEqualTo 2)
+                    assertThat (tryFind "server" headers) (isEqualTo (Some "cowboy"))
+            ) ]
+      ) ]
+
+[<EntryPoint>]
+let main _ = runTests tests

--- a/spike/scriptorium/Spike.fsproj
+++ b/spike/scriptorium/Spike.fsproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <NoWarn>NU1510;NU1701</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- The bindings under test. -->
+    <ProjectReference Include="../../src/Fable.Beam.fsproj" />
+    <!-- Scriptorium is consumed straight from the sibling checkout for the spike; a real migration
+         would use the published NuGet packages (Scriptorium.Quill pulls in Nib, Ink, Parchment). -->
+    <ProjectReference Include="../../../Scriptorium/src/Scriptorium.Quill/Scriptorium.Quill.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/otp/String.fs
+++ b/src/otp/String.fs
@@ -32,8 +32,10 @@ type IExports =
     /// Converts String to a case-folded form suitable for case-insensitive comparisons.
     abstract casefold: s: string -> string
 
-    /// Reverses grapheme clusters in String (Unicode-aware, unlike binary:reverse).
-    abstract reverse: s: string -> string
+    // NOTE: `string:reverse/1` returns a charlist ("olleh"), not a binary, so it cannot be
+    // bound through ImportAll — there is nowhere to convert the result. Use the typed
+    // `reverse` Emit below, which wraps it in `unicode:characters_to_binary/1`.
+    // abstract reverse: s: string -> string
 
     // NOTE: `string:concat/2` is bound to Erlang's `++` operator, which expects
     // charlists — it raises `badarg` when called with binaries. Since F# strings
@@ -60,15 +62,13 @@ type IExports =
     // the chars via `binary_to_list` would be needed — left unbound for now.
     // abstract trim: s: string * dir: Atom * characters: string -> string
 
-    /// Pads String on the trailing side to at least Length grapheme clusters.
-    abstract pad: s: string * length: int -> string
-
-    /// Pads String on the given side Dir to at least Length grapheme clusters.
-    /// Dir must be the atom leading, trailing, or both (use erlang.binaryToAtom).
-    abstract pad: s: string * length: int * dir: Atom -> string
-
-    /// Pads String on the given side Dir with the grapheme cluster Char.
-    abstract pad: s: string * length: int * dir: Atom * char: string -> string
+    // NOTE: every `string:pad` arity returns an *iolist* ([<<"hi">>,32,32,32]), not a binary,
+    // so they cannot be bound through ImportAll — there is nowhere to convert the result.
+    // Use the typed `pad` / `padDir` / `padWith` Emits below, which wrap the result in
+    // `unicode:characters_to_binary/1`.
+    // abstract pad: s: string * length: int -> string
+    // abstract pad: s: string * length: int * dir: Atom -> string
+    // abstract pad: s: string * length: int * dir: Atom * char: string -> string
 
     /// Returns true if S1 and S2 are equal (ordinal).
     abstract equal: s1: string * s2: string -> bool
@@ -114,12 +114,36 @@ let splitFirst (s: string) (pattern: string) : string array = nativeOnly
 [<Emit("fable_utils:new_ref(string:split($0, $1, all))")>]
 let splitAll (s: string) (pattern: string) : string array = nativeOnly
 
+// NOTE on the `unicode:characters_to_binary/1` wrappers below: the OTP `string` module returns
+// *chardata* (an iolist, or a charlist of codepoints) from these functions, not a binary. F#
+// strings are Erlang binaries, so the raw result is structurally wrong even though it prints
+// plausibly — `string:pad("hi", 5)` is `[<<"hi">>,32,32,32]`, which compares unequal to
+// <<"hi   ">>. Flattening at the binding boundary is what makes the F# signature honest.
+
+/// Reverses grapheme clusters in String (Unicode-aware, unlike binary:reverse).
+[<Emit("unicode:characters_to_binary(string:reverse($0))")>]
+let reverse (s: string) : string = nativeOnly
+
+/// Pads String on the trailing side to at least Length grapheme clusters.
+[<Emit("unicode:characters_to_binary(string:pad($0, $1))")>]
+let pad (s: string) (length: int) : string = nativeOnly
+
+/// Pads String on the given side Dir to at least Length grapheme clusters.
+/// Dir must be the atom leading, trailing, or both (use erlang.binaryToAtom).
+[<Emit("unicode:characters_to_binary(string:pad($0, $1, $2))")>]
+let padDir (s: string) (length: int) (dir: Atom) : string = nativeOnly
+
+/// Pads String on the given side Dir with the grapheme cluster Char.
+/// Dir must be the atom leading, trailing, or both (use erlang.binaryToAtom).
+[<Emit("unicode:characters_to_binary(string:pad($0, $1, $2, $3))")>]
+let padWith (s: string) (length: int) (dir: Atom) (char: string) : string = nativeOnly
+
 /// Replaces the first occurrence of SearchPattern in String with Replacement.
-[<Emit("string:replace($0, $1, $2)")>]
+[<Emit("unicode:characters_to_binary(string:replace($0, $1, $2))")>]
 let replaceFirst (s: string) (pattern: string) (replacement: string) : string = nativeOnly
 
 /// Replaces all occurrences of SearchPattern in String with Replacement.
-[<Emit("string:replace($0, $1, $2, all)")>]
+[<Emit("unicode:characters_to_binary(string:replace($0, $1, $2, all))")>]
 let replaceAll (s: string) (pattern: string) (replacement: string) : string = nativeOnly
 
 /// Parses an integer from the start of String.
@@ -133,5 +157,7 @@ let toInteger (s: string) : Result<int * string, string> = nativeOnly
 let toFloat (s: string) : Result<float * string, string> = nativeOnly
 
 /// Returns the grapheme clusters of String as an array.
-[<Emit("fable_utils:new_ref(string:to_graphemes($0))")>]
+/// `string:to_graphemes/1` yields codepoints (97) or codepoint lists for multi-codepoint clusters,
+/// so each cluster is converted back to a binary to match the `string array` signature.
+[<Emit("fable_utils:new_ref([unicode:characters_to_binary([StringGrapheme__]) || StringGrapheme__ <- string:to_graphemes($0)])")>]
 let toGraphemes (s: string) : string array = nativeOnly

--- a/src/otp/UriString.fs
+++ b/src/otp/UriString.fs
@@ -89,7 +89,10 @@ let dissectQuery (queryStr: string) : (string * string) list = nativeOnly
 /// Special characters in keys and values are percent-encoded; spaces are encoded as '+'.
 ///
 /// E.g. composeQuery [("q", "hello world"); ("lang", "en")] → "q=hello+world&lang=en"
-[<Emit("uri_string:compose_query($0)")>]
+///
+/// `uri_string:compose_query/1` returns chardata — notably the empty list `[]` for no pairs, which
+/// is not the empty binary — so the result is flattened to match the `string` signature.
+[<Emit("unicode:characters_to_binary(uri_string:compose_query($0))")>]
 let composeQuery (pairs: (string * string) list) : string = nativeOnly
 
 // ============================================================================

--- a/test/TestBinary.fs
+++ b/test/TestBinary.fs
@@ -130,7 +130,9 @@ let ``test replaceAll replaces all occurrences`` () =
 [<Fact>]
 let ``test binary.longest_common_prefix`` () =
 #if FABLE_COMPILER
-    binary.longest_common_prefix ([ "foobar"; "foobaz"; "fooqux" ]) |> equal 4
+    // "foo" is the longest prefix common to *all three* ("foobar"/"foobaz" share "fooba",
+    // but "fooqux" diverges at the 4th byte).
+    binary.longest_common_prefix ([ "foobar"; "foobaz"; "fooqux" ]) |> equal 3
 #else
     ()
 #endif

--- a/test/TestBinary.fs
+++ b/test/TestBinary.fs
@@ -213,10 +213,15 @@ let ``test binary.decode_unsigned with little endian`` () =
 #endif
 
 [<Fact>]
-let ``test binary.referenced_byte_size returns byte count`` () =
+let ``test binary.referenced_byte_size is at least the logical size`` () =
 #if FABLE_COMPILER
-    binary.referenced_byte_size "hello" |> equal 5
-    binary.referenced_byte_size "" |> equal 0
+    // referenced_byte_size reports the size of the *underlying* memory a (sub-)binary points into,
+    // which OTP's own docs call "a hint for optimization, not exact": for a plain binary it varies
+    // with how the binary was constructed and the OTP release (5 on OTP 25, 40 on OTP 27, 256 for a
+    // shell literal). The only portable guarantee is that it references at least what it contains.
+    let s = "hello"
+    (binary.referenced_byte_size s >= Erlang.byteSize s) |> equal true
+    (binary.referenced_byte_size "" >= 0) |> equal true
 #else
     ()
 #endif

--- a/test/TestErlang.fs
+++ b/test/TestErlang.fs
@@ -87,8 +87,11 @@ let ``test process dictionary get/put/erase`` () =
 [<Fact>]
 let ``test send and receive`` () =
 #if FABLE_COMPILER
-    let pid = Erlang.self ()
-    emitErlExpr () "erlang:self() ! {ping}"
+    // A nullary DU case compiles to a bare atom (`ping`), not a 1-tuple (`{ping}`) -- only a
+    // case *with* fields becomes a tagged tuple, e.g. `Data 42` -> `{data, 42}`. Sending
+    // `{ping}` here never matched the generated receive clause, so this test used to sit out
+    // the full 1000ms timeout and take the None branch.
+    emitErlExpr () "erlang:self() ! ping"
 
     match Erlang.receive<RecvMsg> 1000 with
     | Some Ping -> equal 1 1

--- a/test/TestJsx.fs
+++ b/test/TestJsx.fs
@@ -88,13 +88,22 @@ let ``test jsx format with indent`` () =
     ()
 #endif
 
+// `labels` is a *decoder* option: jsx:is_json/2 does not accept it and simply answers `false`,
+// so is_json can never show that the option took effect. These tests decode instead and inspect
+// the key type of the resulting map -- if Fable stringified the DU case, jsx would receive
+// {labels, <<"atom">>}, silently ignore it, and the keys would stay binaries.
+[<Emit("case maps:keys($0) of [K] -> is_atom(K); _ -> false end")>]
+let private firstKeyIsAtom (m: obj) : bool = nativeOnly
+
+[<Emit("case maps:keys($0) of [K] -> is_binary(K); _ -> false end")>]
+let private firstKeyIsBinary (m: obj) : bool = nativeOnly
+
 [<Fact>]
 let ``test jsx labels Binary keeps keys as binaries`` () =
 #if FABLE_COMPILER
-    // With LabelMode.Binary the decoded map's keys are binaries, so a binary
-    // lookup must succeed. is_json/decode round-trip is enough to prove the
-    // option was accepted by jsx (bad atoms would crash the call).
-    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.Binary ]) |> equal true
+    let decoded: obj = jsx.decode ("""{"key":"value"}""", [ labels LabelMode.Binary ])
+
+    firstKeyIsBinary decoded |> equal true
 #else
     ()
 #endif
@@ -102,18 +111,12 @@ let ``test jsx labels Binary keeps keys as binaries`` () =
 [<Fact>]
 let ``test jsx labels Atom converts keys to atoms`` () =
 #if FABLE_COMPILER
-    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.Atom ]) |> equal true
+    let decoded: obj = jsx.decode ("""{"key":"value"}""", [ labels LabelMode.Atom ])
+
+    firstKeyIsAtom decoded |> equal true
 #else
     ()
 #endif
-
-// Stronger probe: decode a key with LabelMode.Atom and check the resulting
-// key is an atom, not a binary. If the [<Emit>] attribute on the DU case is
-// honoured, jsx receives {labels, atom} and produces an atom key. If Fable
-// stringifies the case name, jsx receives {labels, <<"atom">>}, silently
-// ignores it, and the key stays a binary.
-[<Emit("case maps:keys($0) of [K] -> is_atom(K); _ -> false end")>]
-let private firstKeyIsAtom (m: obj) : bool = nativeOnly
 
 [<Fact>]
 let ``test jsx labels Atom probe emits raw atom option`` () =
@@ -129,11 +132,10 @@ let ``test jsx labels Atom probe emits raw atom option`` () =
 [<Fact>]
 let ``test jsx labels ExistingAtom rejects unknown atoms`` () =
 #if FABLE_COMPILER
-    // Force the atom to exist before decoding.
-    let _ = "definitely_known_key_xyz"
-
-    jsx.is_json ("""{"definitely_known_key_xyz":"value"}""", [ labels LabelMode.ExistingAtom ])
-    |> equal true
+    // existing_atom uses binary_to_existing_atom, so a key whose atom was never created
+    // raises badarg rather than silently interning it. That rejection *is* the behaviour.
+    (fun () -> jsx.decode ("""{"never_interned_key_qqq":"value"}""", [ labels LabelMode.ExistingAtom ]))
+    |> throwsAnyError
 #else
     ()
 #endif
@@ -141,8 +143,12 @@ let ``test jsx labels ExistingAtom rejects unknown atoms`` () =
 [<Fact>]
 let ``test jsx labels AttemptAtom is accepted`` () =
 #if FABLE_COMPILER
-    jsx.is_json ("""{"key":"value"}""", [ labels LabelMode.AttemptAtom ])
-    |> equal true
+    // attempt_atom converts the key when the atom already exists and leaves it a binary
+    // otherwise. "key" is interned by the decode above, so it comes back as an atom.
+    let decoded: obj =
+        jsx.decode ("""{"key":"value"}""", [ labels LabelMode.AttemptAtom ])
+
+    firstKeyIsAtom decoded |> equal true
 #else
     ()
 #endif

--- a/test/TestString.fs
+++ b/test/TestString.fs
@@ -68,7 +68,7 @@ let ``test str.casefold lowercases for comparison`` () =
 [<Fact>]
 let ``test str.reverse reverses string`` () =
 #if FABLE_COMPILER
-    str.reverse "hello" |> equal "olleh"
+    reverse "hello" |> equal "olleh"
 #else
     ()
 #endif
@@ -102,7 +102,7 @@ let ``test str.trim with trailing direction`` () =
 [<Fact>]
 let ``test str.pad trailing to length`` () =
 #if FABLE_COMPILER
-    str.pad ("hi", 5) |> equal "hi   "
+    pad "hi" 5 |> equal "hi   "
 #else
     ()
 #endif
@@ -111,7 +111,7 @@ let ``test str.pad trailing to length`` () =
 let ``test str.pad leading with direction`` () =
 #if FABLE_COMPILER
     let leading = Erlang.binaryToAtom "leading"
-    str.pad ("hi", 5, leading) |> equal "   hi"
+    padDir "hi" 5 leading |> equal "   hi"
 #else
     ()
 #endif
@@ -120,7 +120,7 @@ let ``test str.pad leading with direction`` () =
 let ``test str.pad with custom character`` () =
 #if FABLE_COMPILER
     let leading = Erlang.binaryToAtom "leading"
-    str.pad ("7", 3, leading, "0") |> equal "007"
+    padWith "7" 3 leading "0" |> equal "007"
 #else
     ()
 #endif

--- a/test/test_runner.erl
+++ b/test/test_runner.erl
@@ -2,17 +2,25 @@
 -export([main/1]).
 
 %% Test runner for Fable.Beam tests.
-%% Discovers modules starting with "test_" and runs all test_*/0 functions.
+%% Discovers every module exporting test_*/0 functions and runs them.
+%%
+%% Discovery is by exports, not by module name, on purpose: Fable >= 5.8 qualifies generated
+%% Erlang module names with the OTP app name (test_maps.erl -> fable_beam_test_test_maps.erl),
+%% which silently broke the old lists:prefix("test_", ...) match -- the suite then "passed"
+%% while running zero tests. Hence also the empty-suite guard below.
 
 main([Dir]) ->
     io:format("~n=== Fable.Beam Test Suite ===~n~n"),
     Beams = filelib:wildcard(filename:join(Dir, "*.beam")),
-    Modules = [list_to_atom(filename:basename(F, ".beam")) || F <- Beams,
-               lists:prefix("test_", filename:basename(F, ".beam"))],
+    Loaded = [begin
+                  Mod = list_to_atom(filename:basename(F, ".beam")),
+                  code:purge(Mod),
+                  code:load_file(Mod),
+                  Mod
+              end || F <- Beams],
+    Modules = [Mod || Mod <- Loaded, test_funs(Mod) =/= []],
     {TotalPass, TotalFail} = lists:foldl(
         fun(Mod, {AccPass, AccFail}) ->
-            code:purge(Mod),
-            code:load_file(Mod),
             {P, F} = run_module(Mod),
             {AccPass + P, AccFail + F}
         end,
@@ -23,17 +31,28 @@ main([Dir]) ->
     io:format("~n=== Results ===~n"),
     io:format("Total: ~p | Passed: ~p | Failed: ~p~n",
               [Total, TotalPass, TotalFail]),
-    case TotalFail of
-        0 -> io:format("~nAll tests passed!~n"), ok;
-        _ -> io:format("~nSome tests FAILED!~n"), halt(1)
+    if
+        Total =:= 0 ->
+            io:format("~nNo tests found in ~s -- refusing to report success.~n", [Dir]),
+            halt(1);
+        TotalFail =:= 0 ->
+            io:format("~nAll tests passed!~n"), ok;
+        true ->
+            io:format("~nSome tests FAILED!~n"), halt(1)
+    end.
+
+%% Exported arity-0 functions whose name starts with "test_".
+test_funs(Mod) ->
+    try
+        [F || {F, 0} <- Mod:module_info(exports),
+              F =/= module_info,
+              lists:prefix("test_", atom_to_list(F))]
+    catch
+        _:_ -> []
     end.
 
 run_module(Mod) ->
     io:format("--- ~s ---~n", [Mod]),
-    Exports = Mod:module_info(exports),
-    TestFuns = [F || {F, 0} <- Exports,
-                F =/= module_info,
-                lists:prefix("test_", atom_to_list(F))],
     lists:foldl(
         fun(Fun, {Pass, Fail}) ->
             case run_test(Mod, Fun) of
@@ -42,7 +61,7 @@ run_module(Mod) ->
             end
         end,
         {0, 0},
-        lists:sort(TestFuns)
+        lists:sort(test_funs(Mod))
     ).
 
 run_test(Mod, Fun) ->
@@ -51,10 +70,10 @@ run_test(Mod, Fun) ->
         io:format("  \e[32m✓\e[0m ~s~n", [Fun]),
         pass
     catch
-        error:{assertEqual, Props} ->
-            Expected = proplists:get_value(expected, Props),
-            Actual = proplists:get_value(value, Props),
-            io:format("  \e[31m✗\e[0m ~s~n    expected: ~p~n    actual:   ~p~n", [Fun, Expected, Actual]),
+        %% Shape raised by fable_utils:assert_equal/assert_not_equal.
+        error:#{message := Message, actual := Actual, expected := Expected} ->
+            io:format("  \e[31m✗\e[0m ~s~n    ~ts~n    expected: ~p~n    actual:   ~p~n",
+                      [Fun, Message, Expected, Actual]),
             fail;
         Class:Reason:Stack ->
             io:format("  \e[31m✗\e[0m ~s~n    ~p:~p~n    ~p~n", [Fun, Class, Reason, Stack]),


### PR DESCRIPTION
Upgrades to Fable 5.11 and fixes the issues that upgrade surfaced.

Requires **Fable ≥ 5.11.0**, the first release with the two BEAM fixes this depends on
([#4775](https://github.com/fable-compiler/Fable/pull/4775), [#4776](https://github.com/fable-compiler/Fable/pull/4776)):
`Assert.AreEqual`/`NotEqual` now raise on the BEAM, and erased types (`Pid`/`Atom`/`Shutdown`) no
longer emit reflection calls that fail to resolve. Verified against the stock tool.

## What this fixes

**`Assert.AreEqual` now raises on the BEAM.** Fable's BEAM backend previously lowered it to an
equality *expression* whose boolean result was discarded, so assertions couldn't fail. Fixed upstream
in #4775; the same gap affected Fable's own BEAM test suite. With assertions working, this repo's
suite surfaced 14 real failures, all fixed here — it's now **367/367**, and it can demonstrably fail
(it reported 14, then 6, then 0 as these landed).

**Chardata handling in the `string` bindings (8 fixes).** The OTP `string` module returns *chardata*
— an iolist, or a charlist of codepoints — not a binary. F# strings are binaries, so
`string:pad("hi", 5)` was `[<<"hi">>,32,32,32]`, which compares unequal to `<<"hi   ">>`. Affects
`replace_all`, `replace_first`, the three `pad` arities, `reverse`, `to_graphemes` and
`compose_query`. Now flattened at the binding boundary with `unicode:characters_to_binary/1`, chosen
over `iolist_to_binary/1` because it also handles charlists and codepoints above 255.

Worth knowing for anyone who has been using these: an iolist is still valid chardata, so these values
behaved correctly when passed straight to `io:format`, `file:write` or a Cowboy body — OTP flattens
them. The mismatch only bites when the value is compared, pattern-matched, or stored as a binary.

**Six test corrections.** The bindings they covered were all correct; each was reproduced by hand in
`erl` before being touched. `longest_common_prefix` genuinely returns 3 for that input. The receive
test sent `{ping}` where a nullary DU case compiles to the bare atom `ping`. The four jsx `labels`
tests used `jsx:is_json/2`, which doesn't accept the `labels` decoder option and so could never
observe it — they now decode and assert on the resulting key type.

## Breaking change

`string:reverse` and every `string:pad` arity return chardata, so they can't be bound through
`[<ImportAll>]` — there's nowhere to convert the result. They move to the module's typed-API section,
which is where `String.fs` already says "functions with non-trivial Erlang return values" belong.
Module-level F# functions can't overload, so the arities become distinct names:

| Was | Now |
|---|---|
| `str.reverse s` | `reverse s` |
| `str.pad (s, n)` | `pad s n` |
| `str.pad (s, n, dir)` | `padDir s n dir` |
| `str.pad (s, n, dir, c)` | `padWith s n dir c` |

Pre-1.0 (`-rc.x`), and `synapse` doesn't use any of them, so no known downstream breakage.

## Test-runner hardening

Fable 5.8+ qualifies generated module names with the OTP app name (`test_maps` →
`fable_beam_test_test_maps`), which broke `test_runner.erl`'s `test_`-prefix discovery. It now
discovers tests by **exports** (any module exporting `test_*/0`), so it's robust to naming changes,
and it **refuses to report success on an empty suite** — a discovery bug can't look like a green
build.

## Scriptorium spike

`spike/scriptorium` (`just spike`) runs [Scriptorium](https://github.com/dbrattli/Scriptorium) — Nib
assertions + the Quill runner — on the BEAM against real bindings. No `test_runner.erl` and no
`[<Fact>]`: Quill's runner *is* the `[<EntryPoint>]`, which Fable emits as `main:main/1` and which
halts the VM with the suite's exit code. Failures come with a diff and a clickable source link
(`CallerFilePath` survives the BEAM).

The case for adopting it: Nib's assertions raise from F# itself rather than depending on the backend
lowering `Assert.AreEqual`, and Quill registers tests explicitly rather than rediscovering them by
naming convention — so neither of the two problems above is expressible. Migrating `test/` off the
homegrown runner is the natural follow-up, deliberately not in this PR.

## Verification

```
just test    # 367 passed, 0 failed
just spike   # 11 passed, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)