### PR TITLE
ci: add PaketaBot dependency updates

### DIFF
--- a/.github/workflows/paketabot.yml
+++ b/.github/workflows/paketabot.yml
@@ -1,0 +1,22 @@
+name: PaketaBot
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+      timezone: "Europe/Oslo"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: paketabot-weekly
+  cancel-in-progress: false
+
+jobs:
+  update:
+    uses: cardamomcode/paketabot/.github/workflows/paketabot.yml@v1.0.0
+    permissions:
+      contents: read
+    secrets:
+      paketabot_token: ${{ secrets.PAKETABOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a weekly and manually dispatchable PaketaBot workflow.
- Pin the reusable workflow to the exact immutable
  `cardamomcode/paketabot@v1.0.0` release.
- Pass only the named `PAKETABOT_TOKEN` secret to the isolated publisher job.
- Serialize runs through the `paketabot-weekly` concurrency group.

Fable.Beam's `paket.dependencies` uses only the exact public NuGet.org v3
endpoint supported by PaketaBot v1. The repository-level `PAKETABOT_TOKEN`
secret is configured.

## Validation

- Workflow is byte-for-byte identical to PaketaBot's released v1.0.0 consumer
  example.
- `git diff --check`
- Branch verified current with `origin/main`.

No application or build code changes.
