### PR TITLE
feat: add typed bindings for OTP ports (external processes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Libraries built on top of Fable.Beam:
 | `Fable.Beam.Logger` | `logger` | OTP logger |
 | `Fable.Beam.File` | `file` | File system operations |
 | `Fable.Beam.Os` | `os` | OS interaction, env vars, system time |
+| `Fable.Beam.Port` | `erlang:open_port` | External process ports (line-mode stdio, exit status) |
 | `Fable.Beam.Httpc` | `httpc` | HTTP client (inets) |
 | `Fable.Beam.Init` | `init` | Runtime system control |
 | `Fable.Beam.Testing` | - | Test helpers (Fact, assertions) |
@@ -142,6 +143,37 @@ let valid = jsx.is_json (json, [strict])
 let mini = jsx.minify """{ "key" : "value" }"""
 ```
 
+### Ports (external processes)
+
+Open an external OS process as a typed port. Output is read from the
+process's standard output as newline-delimited lines, and its exit status is
+reported. Arguments are passed as an argument vector — never interpolated
+into a shell command.
+
+```fsharp
+open Fable.Beam.Port
+
+// Resolve the executable on PATH and start it with separate arguments.
+match startOnPath "cat" [] 1024 with
+| Ok port ->
+    send port "hello\n" |> ignore
+    match receive port 1000 with
+    | Some (Line line) -> printfn "%s" line
+    | Some (IncompleteLine frag) -> printfn "partial: %s" frag
+    | Some (ExitStatus code) -> printfn "exited %d" code
+    | None -> printfn "timed out"
+    close port
+| Error reason -> printfn "failed to start: %s" reason
+```
+
+`receive` is a *selective* receive: it only consumes messages from this port
+and leaves unrelated mailbox messages in place, so it composes with
+`Fable.Actor` and other process protocols. Call it from the process that
+opened the port, since ERTS delivers port messages to the opening process.
+Note that when a process ends mid-line, the `ExitStatus` message arrives
+*before* the trailing `IncompleteLine` fragment — keep receiving once more
+if you need that fragment.
+
 ## Prerequisites
 
 - [.NET SDK](https://dotnet.microsoft.com/) 10+
@@ -194,7 +226,7 @@ src/
   otp/             # Fable.Beam — OTP stdlib bindings
     Erlang.fs, GenServer.fs, Supervisor.fs, Timer.fs,
     Ets.fs, Maps.fs, Lists.fs, Io.fs, Logger.fs,
-    File.fs, Os.fs, Httpc.fs, Application.fs, Init.fs,
+    File.fs, Os.fs, Port.fs, Httpc.fs, Application.fs, Init.fs,
     Binary.fs, Math.fs, Proplists.fs, String.fs, Queue.fs,
     Base64.fs, Rand.fs, Testing.fs
   cowboy/          # Fable.Beam.Cowboy — HTTP server bindings

--- a/src/Fable.Beam.fsproj
+++ b/src/Fable.Beam.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="otp/Calendar.fs" />
     <Compile Include="otp/UriString.fs" />
     <Compile Include="otp/Os.fs" />
+    <Compile Include="otp/Port.fs" />
     <Compile Include="otp/File.fs" />
     <Compile Include="otp/Httpc.fs" />
     <Compile Include="otp/Testing.fs" />

--- a/src/otp/Port.fs
+++ b/src/otp/Port.fs
@@ -1,0 +1,68 @@
+/// Typed bindings for OTP ports used to communicate with external OS processes.
+/// See https://www.erlang.org/doc/apps/erts/erlang#open_port-2
+module Fable.Beam.Port
+
+open Fable.Core
+
+// fsharplint:disable MemberNames
+
+/// A running OTP port. This opaque value is valid only on the BEAM runtime.
+///
+/// The API type-checks on .NET, but opening, sending to, closing, and receiving
+/// from ports are BEAM runtime operations implemented by the Fable compiler.
+[<Erase>]
+type Port = private Port of obj
+
+/// A message delivered by a port opened with line mode and `exit_status`.
+///
+/// `IncompleteLine` is an output fragment delivered when a line exceeds the
+/// maximum length supplied at start-up, or when the process ends a line without
+/// a newline. The data is always an Erlang binary, represented as F# `string`.
+///
+/// Note: when the process ends mid-line, ERTS delivers the `ExitStatus` message
+/// *before* the pending `IncompleteLine` fragment. So `ExitStatus` is not a
+/// terminal marker — an `IncompleteLine` may still arrive after it. If you need
+/// the trailing fragment, keep receiving once more after `ExitStatus`.
+type Message =
+    | [<CompiledName("line")>] Line of data: string
+    | [<CompiledName("incomplete_line")>] IncompleteLine of data: string
+    | [<CompiledName("exit_status")>] ExitStatus of status: int
+
+// The emitted code is deliberately the only raw OTP boundary. It constructs
+// `open_port` option tuples and decodes native port mailbox tuples before they
+// reach consuming F# code.
+
+/// Starts an executable at an absolute path with separate argument values.
+///
+/// The process is connected through stdin/stdout in binary, line-delimited mode
+/// and delivers its exit status. `maxLineLength` must be positive. Arguments are
+/// passed as an OTP argument vector, never interpolated into a shell command.
+[<Emit("(fun() -> case $2 > 0 andalso filename:pathtype(binary_to_list($0)) =:= absolute of false -> {error, <<\"path must be absolute and maxLineLength must be positive\">>}; true -> try {ok, erlang:open_port({spawn_executable, binary_to_list($0)}, [binary, {line, $2}, exit_status, use_stdio, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}])} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end)()")>]
+let startAbsolute (path: string) (arguments: string list) (maxLineLength: int) : Result<Port, string> = nativeOnly
+
+/// Finds an executable on `PATH` and starts it with separate argument values.
+///
+/// Resolution uses `os:find_executable/1`; the resolved file is then started
+/// with `spawn_executable`, so this does not invoke a shell or interpolate
+/// argument text. See `startAbsolute` for runtime and line-mode details.
+[<Emit("(fun() -> case $2 > 0 of false -> {error, <<\"maxLineLength must be positive\">>}; true -> case os:find_executable(binary_to_list($0)) of false -> {error, <<\"executable not found on PATH\">>}; PortPath__ -> try {ok, erlang:open_port({spawn_executable, PortPath__}, [binary, {line, $2}, exit_status, use_stdio, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}])} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end end)()")>]
+let startOnPath (name: string) (arguments: string list) (maxLineLength: int) : Result<Port, string> = nativeOnly
+
+/// Sends binary data to the process's standard input.
+///
+/// F# strings compile to Erlang binaries. Returns true when OTP accepted the
+/// command for the port; it raises if the port is no longer valid.
+[<Emit("erlang:port_command($0, $1)")>]
+let send (port: Port) (data: string) : bool = nativeOnly
+
+/// Closes the port and its OS process.
+[<Emit("erlang:port_close($0)")>]
+let close (port: Port) : unit = nativeOnly
+
+/// Selectively receives the next message from this port, or None after timeout.
+///
+/// Messages unrelated to this port remain in the current process mailbox, so
+/// this composes with Fable.Actor and other process protocols without exposing
+/// raw Erlang tuples to callers.
+[<Emit("(fun() -> receive {$0, {data, {eol, PortLineData__}}} -> {line, PortLineData__}; {$0, {data, {noeol, PortFragmentData__}}} -> {incomplete_line, PortFragmentData__}; {$0, {exit_status, PortExitStatus__}} -> {exit_status, PortExitStatus__} after $1 -> undefined end end)()")>]
+let receive (port: Port) (timeoutMs: int) : Message option = nativeOnly

--- a/test/Fable.Beam.Test.fsproj
+++ b/test/Fable.Beam.Test.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="TestCalendar.fs" />
     <Compile Include="TestUriString.fs" />
     <Compile Include="TestOs.fs" />
+    <Compile Include="TestPort.fs" />
     <Compile Include="TestFile.fs" />
     <Compile Include="TestLogger.fs" />
     <Compile Include="TestJsx.fs" />

--- a/test/TestPort.fs
+++ b/test/TestPort.fs
@@ -1,0 +1,164 @@
+module Fable.Beam.Tests.Port
+
+open Fable.Beam.Testing
+
+#if FABLE_COMPILER
+open Fable.Core
+open Fable.Core.BeamInterop
+open Fable.Beam.Port
+
+/// A single-case message used to place an unrelated message in the test process's
+/// mailbox and verify that selective port receive leaves it there. The nullary
+/// case compiles to the bare Erlang atom `unrelated_probe`, matching how the
+/// message is injected below.
+type MailboxProbe = | [<CompiledName("unrelated_probe")>] Unrelated
+#endif
+
+[<Fact>]
+let ``test port streams a complete line and exit status`` () =
+#if FABLE_COMPILER
+    // This is a deliberately small fixture: sh reads one stdin line, echoes it,
+    // and exits. The script is an argument to a fixed executable, not a command
+    // assembled by the port binding.
+    let script = "read line; printf '%s\n' \"$line\"; exit 7"
+
+    let port =
+        match startAbsolute "/bin/sh" [ "-c"; script ] 128 with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    send port "hello from port\n" |> equal true
+
+    match receive port 1000 with
+    | Some(Line data) -> equal "hello from port" data
+    | Some message -> failwithf "expected line data, got %A" message
+    | None -> failwith "timed out waiting for port line"
+
+    match receive port 1000 with
+    | Some(ExitStatus status) -> equal 7 status
+    | Some message -> failwithf "expected exit status, got %A" message
+    | None -> failwith "timed out waiting for port exit status"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port path lookup and close`` () =
+#if FABLE_COMPILER
+    let port =
+        match startOnPath "cat" [] 128 with
+        | Ok port -> port
+        | Error reason -> failwithf "could not find cat on PATH: %s" reason
+
+    send port "close probe\n" |> equal true
+
+    match receive port 1000 with
+    | Some(Line data) -> equal "close probe" data
+    | Some message -> failwithf "expected line data, got %A" message
+    | None -> failwith "timed out waiting for port line"
+
+    close port
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port delivers an incomplete line when the process ends mid-line`` () =
+#if FABLE_COMPILER
+    // `printf` with no trailing newline: the process ends mid-line. With `exit_status`
+    // enabled, ERTS delivers both the pending partial line (`{data, {noeol, ...}}`) and
+    // the exit status. Their relative order is an ERTS implementation detail — on this
+    // runtime the exit status arrives first — so assert on the two trailing messages
+    // without depending on which one is delivered first.
+    let port =
+        match startAbsolute "/bin/sh" [ "-c"; "printf 'partial'; exit 3" ] 128 with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    let trailing =
+        [ receive port 1000; receive port 1000 ]
+        |> List.filter (fun m -> m <> None)
+        |> List.map Option.get
+
+    (trailing
+     |> List.exists (function
+         | IncompleteLine d -> d = "partial"
+         | _ -> false))
+    |> equal true
+
+    (trailing
+     |> List.exists (function
+         | ExitStatus s -> s = 3
+         | _ -> false))
+    |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port receive leaves unrelated mailbox messages behind`` () =
+#if FABLE_COMPILER
+    // Inject an unrelated message into this process's mailbox before the port reads,
+    // to verify the selective port receive skips it and leaves it for the mailbox owner.
+    emitErlExpr () "erlang:self() ! unrelated_probe"
+
+    let port =
+        match startAbsolute "/bin/sh" [ "-c"; "read line; printf '%s\n' \"$line\"; exit 0" ] 128 with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    send port "selective probe\n" |> equal true
+
+    // Selective receive must skip the unrelated message and deliver the port line.
+    match receive port 1000 with
+    | Some(Line data) -> equal "selective probe" data
+    | Some message -> failwithf "expected line data, got %A" message
+    | None -> failwith "timed out waiting for port line"
+
+    // Drain the port's exit status; selective receive still skips the unrelated message.
+    match receive port 1000 with
+    | Some(ExitStatus status) -> equal 0 status
+    | Some message -> failwithf "expected exit status, got %A" message
+    | None -> failwith "timed out waiting for exit status"
+
+    // The unrelated message must still be in the mailbox, undisturbed.
+    match Erlang.receive<MailboxProbe> 1000 with
+    | Some Unrelated -> equal 1 1
+    | _ -> failwith "unrelated mailbox message was lost by selective receive"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port startAbsolute rejects a relative path`` () =
+#if FABLE_COMPILER
+    match startAbsolute "some/relative/path" [] 128 with
+    | Error reason -> equal "path must be absolute and maxLineLength must be positive" reason
+    | Ok _ -> failwith "expected an error for a relative path"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port startOnPath errors when the executable is missing`` () =
+#if FABLE_COMPILER
+    match startOnPath "definitely_not_a_real_executable_xyz" [] 128 with
+    | Error reason -> equal "executable not found on PATH" reason
+    | Ok _ -> failwith "expected an error for a missing executable"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port rejects a non-positive maxLineLength`` () =
+#if FABLE_COMPILER
+    match startAbsolute "/bin/sh" [] 0 with
+    | Error reason -> equal "path must be absolute and maxLineLength must be positive" reason
+    | Ok _ -> failwith "expected an error for maxLineLength 0"
+
+    match startOnPath "cat" [] 0 with
+    | Error reason -> equal "maxLineLength must be positive" reason
+    | Ok _ -> failwith "expected an error for maxLineLength 0"
+#else
+    ()
+#endif


### PR DESCRIPTION
## Summary

Adds a new `Fable.Beam.Port` module providing typed F# bindings for OTP ports, used to communicate with external OS processes.

### New API
- `startAbsolute` — start an executable at an absolute path via `spawn_executable`
- `startOnPath` — resolve an executable on PATH (`os:find_executable`) and start it
- `send` — write binary data to the process's stdin
- `receive` — selective receive of line/incomplete-line/exit-status messages; unrelated mailbox messages are left in place, so it composes with `Fable.Actor`
- `close` — close the port and its OS process

Both start functions validate `maxLineLength > 0` and return `Result<Port, string>`.

### Security
Arguments are passed as an OTP argument vector ({args, [...]}), never interpolated into a shell command string.

### Docs
README updated with a usage example, the ports table row, and a note about ERTS delivering `ExitStatus` before a trailing `IncompleteLine` fragment.

### Tests
New `test/TestPort.fs` (7 BEAM tests): complete line + exit status, path lookup, mid-line termination, selective receive leaving unrelated mailbox messages undisturbed, and error paths (relative path, missing executable, non-positive maxLineLength).

Generated with Qwen Code