### PR TITLE
feat: expand OTP port lifecycle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Libraries built on top of Fable.Beam:
 | `Fable.Beam.Logger` | `logger` | OTP logger |
 | `Fable.Beam.File` | `file` | File system operations |
 | `Fable.Beam.Os` | `os` | OS interaction, env vars, system time |
-| `Fable.Beam.Port` | `erlang:open_port` | External process ports (line-mode stdio, exit status) |
+| `Fable.Beam.Port` | `erlang:open_port` | Configurable external-process ports, lifecycle, and monitoring |
 | `Fable.Beam.Httpc` | `httpc` | HTTP client (inets) |
 | `Fable.Beam.Init` | `init` | Runtime system control |
 | `Fable.Beam.Testing` | - | Test helpers (Fact, assertions) |
@@ -147,22 +147,33 @@ let mini = jsx.minify """{ "key" : "value" }"""
 
 Open an external OS process as a typed port. Output is read from the
 process's standard output as newline-delimited lines, and its exit status is
-reported. Arguments are passed as an argument vector — never interpolated
-into a shell command.
+reported by default. `PortOptions` keeps the launch configuration explicit;
+arguments are passed as an argument vector — never interpolated into a shell
+command.
 
 ```fsharp
 open Fable.Beam.Port
 
-// Resolve the executable on PATH and start it with separate arguments.
-match startOnPath "cat" [] 1024 with
+let options =
+    { PortOptions.defaultOptions with
+        arguments = []
+        maxLineLength = 1024 }
+
+// Resolve the executable on PATH and start it with explicit options.
+match startOnPath "cat" options with
 | Ok port ->
-    send port "hello\n" |> ignore
-    match receive port 1000 with
-    | Some (Line line) -> printfn "%s" line
-    | Some (IncompleteLine frag) -> printfn "partial: %s" frag
-    | Some (ExitStatus code) -> printfn "exited %d" code
-    | None -> printfn "timed out"
-    close port
+    match trySend port "hello\n" with
+    | Ok () ->
+        receiveUntil port 1000
+        |> List.iter (function
+            | Line line -> printfn "%s" line
+            | IncompleteLine fragment -> printfn "partial: %s" fragment
+            | ExitStatus code -> printfn "exited %d" code)
+    | Error reason -> printfn "send failed: %s" reason
+
+    match tryClose port with
+    | Ok () -> ()
+    | Error reason -> printfn "close failed: %s" reason
 | Error reason -> printfn "failed to start: %s" reason
 ```
 
@@ -170,9 +181,11 @@ match startOnPath "cat" [] 1024 with
 and leaves unrelated mailbox messages in place, so it composes with
 `Fable.Actor` and other process protocols. Call it from the process that
 opened the port, since ERTS delivers port messages to the opening process.
-Note that when a process ends mid-line, the `ExitStatus` message arrives
-*before* the trailing `IncompleteLine` fragment — keep receiving once more
-if you need that fragment.
+For line-mode consumption, prefer `receiveUntil` or `foldMessages`: they
+preserve a trailing `IncompleteLine` when ERTS delivers `ExitStatus` first.
+Options also support a working directory, environment overrides, stderr
+redirection, owner linking, and independent `monitor`/`receiveDown` exit
+notifications.
 
 ## Prerequisites
 

--- a/src/otp/Port.fs
+++ b/src/otp/Port.fs
@@ -13,7 +13,41 @@ open Fable.Core
 [<Erase>]
 type Port = private Port of obj
 
-/// A message delivered by a port opened with line mode and `exit_status`.
+/// A monitor installed for a port. It is owned by the process that called
+/// `monitor`, and can be consumed with `receiveDown`.
+[<Erase>]
+type PortMonitor = private PortMonitor of obj
+
+/// Launch and ownership settings for a port.
+///
+/// `arguments` is always an argument vector, never a shell command string.
+/// `environment` supplies overrides to the child environment. `linkOwner`
+/// opts into OTP link semantics; it is false by default so an unexpected child
+/// exit cannot terminate the caller.
+type PortOptions =
+    { arguments: string list
+      maxLineLength: int
+      exitStatus: bool
+      useStdio: bool
+      stderrToStdout: bool
+      workingDirectory: string option
+      environment: (string * string) list
+      linkOwner: bool }
+
+/// Safe defaults for a line-oriented stdin/stdout process connection.
+module PortOptions =
+    let defaultOptions =
+        { arguments = []
+          maxLineLength = 8192
+          exitStatus = true
+          useStdio = true
+          stderrToStdout = false
+          workingDirectory = None
+          environment = []
+          linkOwner = false }
+
+/// A message delivered by a port opened with line mode. `ExitStatus` is
+/// delivered when `PortOptions.exitStatus` is enabled.
 ///
 /// `IncompleteLine` is an output fragment delivered when a line exceeds the
 /// maximum length supplied at start-up, or when the process ends a line without
@@ -28,25 +62,71 @@ type Message =
     | [<CompiledName("incomplete_line")>] IncompleteLine of data: string
     | [<CompiledName("exit_status")>] ExitStatus of status: int
 
+/// A down notification emitted for a monitored port.
+type Down = Down of reason: string
+
 // The emitted code is deliberately the only raw OTP boundary. It constructs
 // `open_port` option tuples and decodes native port mailbox tuples before they
 // reach consuming F# code.
 
-/// Starts an executable at an absolute path with separate argument values.
-///
-/// The process is connected through stdin/stdout in binary, line-delimited mode
-/// and delivers its exit status. `maxLineLength` must be positive. Arguments are
-/// passed as an OTP argument vector, never interpolated into a shell command.
-[<Emit("(fun() -> case $2 > 0 andalso filename:pathtype(binary_to_list($0)) =:= absolute of false -> {error, <<\"path must be absolute and maxLineLength must be positive\">>}; true -> try {ok, erlang:open_port({spawn_executable, binary_to_list($0)}, [binary, {line, $2}, exit_status, use_stdio, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}])} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end)()")>]
-let startAbsolute (path: string) (arguments: string list) (maxLineLength: int) : Result<Port, string> = nativeOnly
+/// Starts an executable at an absolute path using explicit port options.
+/// `maxLineLength` must be positive. `stderrToStdout` requires `useStdio`.
+[<Emit("(fun() -> case $2 > 0 andalso filename:pathtype(binary_to_list($0)) =:= absolute andalso (not $5 orelse $4) of false -> {error, <<\"path must be absolute, maxLineLength must be positive, and stderrToStdout requires useStdio\">>}; true -> PortDirectoryOpts__ = case $6 of undefined -> []; PortWorkingDirectory__ -> [{cd, binary_to_list(PortWorkingDirectory__)}] end, PortEnvironmentOpts__ = case $7 of [] -> []; PortEnvironment__ -> [{env, [{binary_to_list(PortEnvironmentKey__), binary_to_list(PortEnvironmentValue__)} || {PortEnvironmentKey__, PortEnvironmentValue__} <- PortEnvironment__]}] end, PortExitStatusOpts__ = case $3 of true -> [exit_status]; false -> [] end, PortStdioOpts__ = case $4 of true -> [use_stdio]; false -> [] end, PortStderrOpts__ = case $5 of true -> [stderr_to_stdout]; false -> [] end, PortLinkOpts__ = case $8 of true -> [link]; false -> [] end, PortOpts__ = [binary, {line, $2}, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}] ++ PortExitStatusOpts__ ++ PortStdioOpts__ ++ PortStderrOpts__ ++ PortDirectoryOpts__ ++ PortEnvironmentOpts__ ++ PortLinkOpts__, try {ok, erlang:open_port({spawn_executable, binary_to_list($0)}, PortOpts__)} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end)()")>]
+let private startAbsoluteImpl
+    (path: string)
+    (arguments: string list)
+    (maxLineLength: int)
+    (exitStatus: bool)
+    (useStdio: bool)
+    (stderrToStdout: bool)
+    (workingDirectory: string option)
+    (environment: (string * string) list)
+    (linkOwner: bool)
+    : Result<Port, string> =
+    nativeOnly
+
+let startAbsolute (path: string) (options: PortOptions) : Result<Port, string> =
+    startAbsoluteImpl
+        path
+        options.arguments
+        options.maxLineLength
+        options.exitStatus
+        options.useStdio
+        options.stderrToStdout
+        options.workingDirectory
+        options.environment
+        options.linkOwner
 
 /// Finds an executable on `PATH` and starts it with separate argument values.
 ///
 /// Resolution uses `os:find_executable/1`; the resolved file is then started
 /// with `spawn_executable`, so this does not invoke a shell or interpolate
 /// argument text. See `startAbsolute` for runtime and line-mode details.
-[<Emit("(fun() -> case $2 > 0 of false -> {error, <<\"maxLineLength must be positive\">>}; true -> case os:find_executable(binary_to_list($0)) of false -> {error, <<\"executable not found on PATH\">>}; PortPath__ -> try {ok, erlang:open_port({spawn_executable, PortPath__}, [binary, {line, $2}, exit_status, use_stdio, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}])} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end end)()")>]
-let startOnPath (name: string) (arguments: string list) (maxLineLength: int) : Result<Port, string> = nativeOnly
+[<Emit("(fun() -> case $2 > 0 andalso (not $5 orelse $4) of false -> {error, <<\"maxLineLength must be positive and stderrToStdout requires useStdio\">>}; true -> case os:find_executable(binary_to_list($0)) of false -> {error, <<\"executable not found on PATH\">>}; PortPath__ -> PortDirectoryOpts__ = case $6 of undefined -> []; PortWorkingDirectory__ -> [{cd, binary_to_list(PortWorkingDirectory__)}] end, PortEnvironmentOpts__ = case $7 of [] -> []; PortEnvironment__ -> [{env, [{binary_to_list(PortEnvironmentKey__), binary_to_list(PortEnvironmentValue__)} || {PortEnvironmentKey__, PortEnvironmentValue__} <- PortEnvironment__]}] end, PortExitStatusOpts__ = case $3 of true -> [exit_status]; false -> [] end, PortStdioOpts__ = case $4 of true -> [use_stdio]; false -> [] end, PortStderrOpts__ = case $5 of true -> [stderr_to_stdout]; false -> [] end, PortLinkOpts__ = case $8 of true -> [link]; false -> [] end, PortOpts__ = [binary, {line, $2}, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}] ++ PortExitStatusOpts__ ++ PortStdioOpts__ ++ PortStderrOpts__ ++ PortDirectoryOpts__ ++ PortEnvironmentOpts__ ++ PortLinkOpts__, try {ok, erlang:open_port({spawn_executable, PortPath__}, PortOpts__)} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end end)()")>]
+let private startOnPathImpl
+    (name: string)
+    (arguments: string list)
+    (maxLineLength: int)
+    (exitStatus: bool)
+    (useStdio: bool)
+    (stderrToStdout: bool)
+    (workingDirectory: string option)
+    (environment: (string * string) list)
+    (linkOwner: bool)
+    : Result<Port, string> =
+    nativeOnly
+
+let startOnPath (name: string) (options: PortOptions) : Result<Port, string> =
+    startOnPathImpl
+        name
+        options.arguments
+        options.maxLineLength
+        options.exitStatus
+        options.useStdio
+        options.stderrToStdout
+        options.workingDirectory
+        options.environment
+        options.linkOwner
 
 /// Sends binary data to the process's standard input.
 ///
@@ -55,9 +135,25 @@ let startOnPath (name: string) (arguments: string list) (maxLineLength: int) : R
 [<Emit("erlang:port_command($0, $1)")>]
 let send (port: Port) (data: string) : bool = nativeOnly
 
+/// Sends data without raising when the port has already disappeared.
+[<Emit("(fun() -> try case erlang:port_command($0, $1) of true -> {ok, []}; false -> {error, <<\"port command was not accepted\">>} end catch error:PortSendReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortSendReason__]))} end end)()")>]
+let trySend (port: Port) (data: string) : Result<unit, string> = nativeOnly
+
 /// Closes the port and its OS process.
 [<Emit("erlang:port_close($0)")>]
 let close (port: Port) : unit = nativeOnly
+
+/// Closes a port without raising when it has already disappeared.
+[<Emit("(fun() -> try erlang:port_close($0), {ok, []} catch error:PortCloseReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortCloseReason__]))} end end)()")>]
+let tryClose (port: Port) : Result<unit, string> = nativeOnly
+
+/// Monitors a port without linking it to the caller.
+[<Emit("erlang:monitor(port, $0)")>]
+let monitor (port: Port) : PortMonitor = nativeOnly
+
+/// Selectively receives the down notification for a monitored port.
+[<Emit("(fun() -> receive {'DOWN', $1, port, $0, PortDownReason__} -> {down, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortDownReason__]))} after $2 -> undefined end end)()")>]
+let receiveDown (port: Port) (monitor: PortMonitor) (timeoutMs: int) : Down option = nativeOnly
 
 /// Selectively receives the next message from this port, or None after timeout.
 ///
@@ -66,3 +162,28 @@ let close (port: Port) : unit = nativeOnly
 /// raw Erlang tuples to callers.
 [<Emit("(fun() -> receive {$0, {data, {eol, PortLineData__}}} -> {line, PortLineData__}; {$0, {data, {noeol, PortFragmentData__}}} -> {incomplete_line, PortFragmentData__}; {$0, {exit_status, PortExitStatus__}} -> {exit_status, PortExitStatus__} after $1 -> undefined end end)()")>]
 let receive (port: Port) (timeoutMs: int) : Message option = nativeOnly
+
+/// Folds port messages until the port exits or the next receive times out.
+///
+/// The timeout applies to each receive. If ERTS delivers `ExitStatus` before
+/// its final `IncompleteLine`, this function receives and folds that trailing
+/// fragment before returning. With `exitStatus = false`, it returns when a
+/// receive times out. This is the preferred line-mode consumption loop.
+let foldMessages (port: Port) (timeoutMs: int) (folder: 'State -> Message -> 'State) (state: 'State) : 'State =
+    let rec loop state =
+        match receive port timeoutMs with
+        | None -> state
+        | Some(ExitStatus _ as message) ->
+            let state = folder state message
+
+            match receive port timeoutMs with
+            | Some(IncompleteLine _ as trailing) -> folder state trailing
+            | _ -> state
+        | Some message -> loop (folder state message)
+
+    loop state
+
+/// Receives all messages through exit (and its possible trailing fragment).
+let receiveUntil (port: Port) (timeoutMs: int) : Message list =
+    foldMessages port timeoutMs (fun messages message -> message :: messages) []
+    |> List.rev

--- a/src/otp/Port.fs
+++ b/src/otp/Port.fs
@@ -65,68 +65,86 @@ type Message =
 /// A down notification emitted for a monitored port.
 type Down = Down of reason: string
 
-// The emitted code is deliberately the only raw OTP boundary. It constructs
-// `open_port` option tuples and decodes native port mailbox tuples before they
-// reach consuming F# code.
+// The emitted code is deliberately the only raw OTP boundary. Small helpers
+// construct OTP-only atoms and tuples; F# composes them into the option list.
+
+[<Emit("binary")>]
+let private binaryOption: obj = nativeOnly
+
+[<Emit("{line, $0}")>]
+let private lineOption (maxLineLength: int) : obj = nativeOnly
+
+[<Emit("{args, [binary_to_list(PortArg__) || PortArg__ <- $0]}")>]
+let private argumentsOption (arguments: string list) : obj = nativeOnly
+
+[<Emit("exit_status")>]
+let private exitStatusOption: obj = nativeOnly
+
+[<Emit("use_stdio")>]
+let private useStdioOption: obj = nativeOnly
+
+[<Emit("stderr_to_stdout")>]
+let private stderrToStdoutOption: obj = nativeOnly
+
+[<Emit("link")>]
+let private linkOption: obj = nativeOnly
+
+[<Emit("{cd, binary_to_list($0)}")>]
+let private workingDirectoryOption (path: string) : obj = nativeOnly
+
+[<Emit("{env, [{binary_to_list(PortEnvironmentKey__), binary_to_list(PortEnvironmentValue__)} || {PortEnvironmentKey__, PortEnvironmentValue__} <- $0]}")>]
+let private environmentOption (environment: (string * string) list) : obj = nativeOnly
+
+[<Emit("filename:pathtype(binary_to_list($0)) =:= absolute")>]
+let private isAbsolutePath (path: string) : bool = nativeOnly
+
+[<Emit("(fun() -> case os:find_executable(binary_to_list($0)) of false -> undefined; PortPath__ -> erlang:list_to_binary(PortPath__) end end)()")>]
+let private findExecutable (name: string) : string option = nativeOnly
+
+[<Emit("(fun() -> try {ok, erlang:open_port({spawn_executable, binary_to_list($0)}, $1)} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end)()")>]
+let private openExecutable (path: string) (options: obj list) : Result<Port, string> = nativeOnly
+
+let private launchOptions (options: PortOptions) =
+    let optional enabled option = if enabled then [ option ] else []
+
+    let workingDirectory =
+        match options.workingDirectory with
+        | Some path -> [ workingDirectoryOption path ]
+        | None -> []
+
+    [ binaryOption
+      lineOption options.maxLineLength
+      argumentsOption options.arguments ]
+    @ optional options.exitStatus exitStatusOption
+    @ optional options.useStdio useStdioOption
+    @ optional options.stderrToStdout stderrToStdoutOption
+    @ workingDirectory
+    @ optional (not options.environment.IsEmpty) (environmentOption options.environment)
+    @ optional options.linkOwner linkOption
+
+let private hasValidOptions (options: PortOptions) =
+    options.maxLineLength > 0 && (not options.stderrToStdout || options.useStdio)
 
 /// Starts an executable at an absolute path using explicit port options.
 /// `maxLineLength` must be positive. `stderrToStdout` requires `useStdio`.
-[<Emit("(fun() -> case $2 > 0 andalso filename:pathtype(binary_to_list($0)) =:= absolute andalso (not $5 orelse $4) of false -> {error, <<\"path must be absolute, maxLineLength must be positive, and stderrToStdout requires useStdio\">>}; true -> PortDirectoryOpts__ = case $6 of undefined -> []; PortWorkingDirectory__ -> [{cd, binary_to_list(PortWorkingDirectory__)}] end, PortEnvironmentOpts__ = case $7 of [] -> []; PortEnvironment__ -> [{env, [{binary_to_list(PortEnvironmentKey__), binary_to_list(PortEnvironmentValue__)} || {PortEnvironmentKey__, PortEnvironmentValue__} <- PortEnvironment__]}] end, PortExitStatusOpts__ = case $3 of true -> [exit_status]; false -> [] end, PortStdioOpts__ = case $4 of true -> [use_stdio]; false -> [] end, PortStderrOpts__ = case $5 of true -> [stderr_to_stdout]; false -> [] end, PortLinkOpts__ = case $8 of true -> [link]; false -> [] end, PortOpts__ = [binary, {line, $2}, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}] ++ PortExitStatusOpts__ ++ PortStdioOpts__ ++ PortStderrOpts__ ++ PortDirectoryOpts__ ++ PortEnvironmentOpts__ ++ PortLinkOpts__, try {ok, erlang:open_port({spawn_executable, binary_to_list($0)}, PortOpts__)} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end)()")>]
-let private startAbsoluteImpl
-    (path: string)
-    (arguments: string list)
-    (maxLineLength: int)
-    (exitStatus: bool)
-    (useStdio: bool)
-    (stderrToStdout: bool)
-    (workingDirectory: string option)
-    (environment: (string * string) list)
-    (linkOwner: bool)
-    : Result<Port, string> =
-    nativeOnly
-
 let startAbsolute (path: string) (options: PortOptions) : Result<Port, string> =
-    startAbsoluteImpl
-        path
-        options.arguments
-        options.maxLineLength
-        options.exitStatus
-        options.useStdio
-        options.stderrToStdout
-        options.workingDirectory
-        options.environment
-        options.linkOwner
+    if not (isAbsolutePath path && hasValidOptions options) then
+        Error "path must be absolute, maxLineLength must be positive, and stderrToStdout requires useStdio"
+    else
+        openExecutable path (launchOptions options)
 
 /// Finds an executable on `PATH` and starts it with separate argument values.
 ///
 /// Resolution uses `os:find_executable/1`; the resolved file is then started
 /// with `spawn_executable`, so this does not invoke a shell or interpolate
 /// argument text. See `startAbsolute` for runtime and line-mode details.
-[<Emit("(fun() -> case $2 > 0 andalso (not $5 orelse $4) of false -> {error, <<\"maxLineLength must be positive and stderrToStdout requires useStdio\">>}; true -> case os:find_executable(binary_to_list($0)) of false -> {error, <<\"executable not found on PATH\">>}; PortPath__ -> PortDirectoryOpts__ = case $6 of undefined -> []; PortWorkingDirectory__ -> [{cd, binary_to_list(PortWorkingDirectory__)}] end, PortEnvironmentOpts__ = case $7 of [] -> []; PortEnvironment__ -> [{env, [{binary_to_list(PortEnvironmentKey__), binary_to_list(PortEnvironmentValue__)} || {PortEnvironmentKey__, PortEnvironmentValue__} <- PortEnvironment__]}] end, PortExitStatusOpts__ = case $3 of true -> [exit_status]; false -> [] end, PortStdioOpts__ = case $4 of true -> [use_stdio]; false -> [] end, PortStderrOpts__ = case $5 of true -> [stderr_to_stdout]; false -> [] end, PortLinkOpts__ = case $8 of true -> [link]; false -> [] end, PortOpts__ = [binary, {line, $2}, {args, [binary_to_list(PortArg__) || PortArg__ <- $1]}] ++ PortExitStatusOpts__ ++ PortStdioOpts__ ++ PortStderrOpts__ ++ PortDirectoryOpts__ ++ PortEnvironmentOpts__ ++ PortLinkOpts__, try {ok, erlang:open_port({spawn_executable, PortPath__}, PortOpts__)} catch error:PortStartReason__ -> {error, erlang:iolist_to_binary(io_lib:format(\"~p\", [PortStartReason__]))} end end end end)()")>]
-let private startOnPathImpl
-    (name: string)
-    (arguments: string list)
-    (maxLineLength: int)
-    (exitStatus: bool)
-    (useStdio: bool)
-    (stderrToStdout: bool)
-    (workingDirectory: string option)
-    (environment: (string * string) list)
-    (linkOwner: bool)
-    : Result<Port, string> =
-    nativeOnly
-
 let startOnPath (name: string) (options: PortOptions) : Result<Port, string> =
-    startOnPathImpl
-        name
-        options.arguments
-        options.maxLineLength
-        options.exitStatus
-        options.useStdio
-        options.stderrToStdout
-        options.workingDirectory
-        options.environment
-        options.linkOwner
+    if not (hasValidOptions options) then
+        Error "maxLineLength must be positive and stderrToStdout requires useStdio"
+    else
+        match findExecutable name with
+        | Some path -> openExecutable path (launchOptions options)
+        | None -> Error "executable not found on PATH"
 
 /// Sends binary data to the process's standard input.
 ///

--- a/test/TestPort.fs
+++ b/test/TestPort.fs
@@ -12,6 +12,11 @@ open Fable.Beam.Port
 /// case compiles to the bare Erlang atom `unrelated_probe`, matching how the
 /// message is injected below.
 type MailboxProbe = | [<CompiledName("unrelated_probe")>] Unrelated
+
+let private options arguments maxLineLength =
+    { PortOptions.defaultOptions with
+        arguments = arguments
+        maxLineLength = maxLineLength }
 #endif
 
 [<Fact>]
@@ -23,7 +28,7 @@ let ``test port streams a complete line and exit status`` () =
     let script = "read line; printf '%s\n' \"$line\"; exit 7"
 
     let port =
-        match startAbsolute "/bin/sh" [ "-c"; script ] 128 with
+        match startAbsolute "/bin/sh" (options [ "-c"; script ] 128) with
         | Ok port -> port
         | Error reason -> failwithf "could not start port fixture: %s" reason
 
@@ -46,7 +51,7 @@ let ``test port streams a complete line and exit status`` () =
 let ``test port path lookup and close`` () =
 #if FABLE_COMPILER
     let port =
-        match startOnPath "cat" [] 128 with
+        match startOnPath "cat" (options [] 128) with
         | Ok port -> port
         | Error reason -> failwithf "could not find cat on PATH: %s" reason
 
@@ -71,7 +76,7 @@ let ``test port delivers an incomplete line when the process ends mid-line`` () 
     // runtime the exit status arrives first — so assert on the two trailing messages
     // without depending on which one is delivered first.
     let port =
-        match startAbsolute "/bin/sh" [ "-c"; "printf 'partial'; exit 3" ] 128 with
+        match startAbsolute "/bin/sh" (options [ "-c"; "printf 'partial'; exit 3" ] 128) with
         | Ok port -> port
         | Error reason -> failwithf "could not start port fixture: %s" reason
 
@@ -103,7 +108,7 @@ let ``test port receive leaves unrelated mailbox messages behind`` () =
     emitErlExpr () "erlang:self() ! unrelated_probe"
 
     let port =
-        match startAbsolute "/bin/sh" [ "-c"; "read line; printf '%s\n' \"$line\"; exit 0" ] 128 with
+        match startAbsolute "/bin/sh" (options [ "-c"; "read line; printf '%s\n' \"$line\"; exit 0" ] 128) with
         | Ok port -> port
         | Error reason -> failwithf "could not start port fixture: %s" reason
 
@@ -132,8 +137,9 @@ let ``test port receive leaves unrelated mailbox messages behind`` () =
 [<Fact>]
 let ``test port startAbsolute rejects a relative path`` () =
 #if FABLE_COMPILER
-    match startAbsolute "some/relative/path" [] 128 with
-    | Error reason -> equal "path must be absolute and maxLineLength must be positive" reason
+    match startAbsolute "some/relative/path" (options [] 128) with
+    | Error reason ->
+        equal "path must be absolute, maxLineLength must be positive, and stderrToStdout requires useStdio" reason
     | Ok _ -> failwith "expected an error for a relative path"
 #else
     ()
@@ -142,7 +148,7 @@ let ``test port startAbsolute rejects a relative path`` () =
 [<Fact>]
 let ``test port startOnPath errors when the executable is missing`` () =
 #if FABLE_COMPILER
-    match startOnPath "definitely_not_a_real_executable_xyz" [] 128 with
+    match startOnPath "definitely_not_a_real_executable_xyz" (options [] 128) with
     | Error reason -> equal "executable not found on PATH" reason
     | Ok _ -> failwith "expected an error for a missing executable"
 #else
@@ -152,13 +158,108 @@ let ``test port startOnPath errors when the executable is missing`` () =
 [<Fact>]
 let ``test port rejects a non-positive maxLineLength`` () =
 #if FABLE_COMPILER
-    match startAbsolute "/bin/sh" [] 0 with
-    | Error reason -> equal "path must be absolute and maxLineLength must be positive" reason
+    match startAbsolute "/bin/sh" (options [] 0) with
+    | Error reason ->
+        equal "path must be absolute, maxLineLength must be positive, and stderrToStdout requires useStdio" reason
     | Ok _ -> failwith "expected an error for maxLineLength 0"
 
-    match startOnPath "cat" [] 0 with
-    | Error reason -> equal "maxLineLength must be positive" reason
+    match startOnPath "cat" (options [] 0) with
+    | Error reason -> equal "maxLineLength must be positive and stderrToStdout requires useStdio" reason
     | Ok _ -> failwith "expected an error for maxLineLength 0"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port options redirect stderr and apply child environment`` () =
+#if FABLE_COMPILER
+    let portOptions =
+        { options
+              [ "-c"
+                "printf '%s:%s\\n' \"$PORT_TEST_VALUE\" \"$PWD\"; printf 'diagnostic\\n' >&2" ]
+              128 with
+            stderrToStdout = true
+            workingDirectory = Some "/tmp"
+            environment = [ "PORT_TEST_VALUE", "configured" ] }
+
+    let port =
+        match startAbsolute "/bin/sh" portOptions with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start configured port fixture: %s" reason
+
+    receiveUntil port 1000
+    |> List.filter (function
+        | Line _ -> true
+        | _ -> false)
+    |> List.map (function
+        | Line data -> data
+        | _ -> failwith "unreachable")
+    |> equal [ "configured:/tmp"; "diagnostic" ]
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port lifecycle operations are non-throwing after exit`` () =
+#if FABLE_COMPILER
+    let port =
+        match startAbsolute "/bin/sh" (options [ "-c"; "exit 0" ] 128) with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    receiveUntil port 1000 |> ignore
+
+    match trySend port "too late\n" with
+    | Error _ -> ()
+    | Ok() -> failwith "sending to an exited port should fail"
+
+    match tryClose port with
+    | Error _ -> ()
+    | Ok() -> failwith "closing an exited port should fail"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test port foldMessages keeps trailing oversized JSONL fragments after exit status`` () =
+#if FABLE_COMPILER
+    let port =
+        match startAbsolute "/bin/sh" (options [ "-c"; "printf '{\\\"value\\\":\\\"0123456789\\\"}'" ] 8) with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    let messages =
+        foldMessages port 1000 (fun messages message -> message :: messages) []
+        |> List.rev
+
+    (messages
+     |> List.exists (function
+         | ExitStatus 0 -> true
+         | _ -> false))
+    |> equal true
+
+    (messages
+     |> List.exists (function
+         | IncompleteLine data -> data.Contains "0123456789" || data.Length = 8
+         | _ -> false))
+    |> equal true
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test monitored port emits a typed down notification`` () =
+#if FABLE_COMPILER
+    let port =
+        match startAbsolute "/bin/sh" (options [ "-c"; "exit 0" ] 128) with
+        | Ok port -> port
+        | Error reason -> failwithf "could not start port fixture: %s" reason
+
+    let portMonitor = monitor port
+
+    match receiveDown port portMonitor 1000 with
+    | Some(Down reason) -> reason |> equal "normal"
+    | None -> failwith "timed out waiting for port down notification"
 #else
     ()
 #endif


### PR DESCRIPTION
## Summary
- replace fixed port startup arguments with a typed PortOptions record
- add non-throwing lifecycle, monitoring, and ordered receive helpers
- cover stderr, configured child environments, post-exit races, oversized frames, and down notifications

## Validation
- just format-check
- just test: 411 passed