### PR TITLE
docs: add curried API migration guidance

### DIFF
--- a/MIGRATING-TO-CURRIED-API.md
+++ b/MIGRATING-TO-CURRIED-API.md
@@ -1,9 +1,9 @@
-# Migrating to v5
+# Migrating to the curried API
 
-v5 makes the public binding API consistently curried. Functions take their
-configuration or input first and the value being transformed last, which makes
-ordinary F# pipelines work naturally. The old public `ImportAll` objects and
-their tupled calls are gone.
+The current 5.0 release candidates make the public binding API consistently
+curried. Functions take their configuration or input first and the value being
+transformed last, which makes ordinary F# pipelines work naturally. The old
+public `ImportAll` objects and their tupled calls are gone.
 
 ## Update calls
 
@@ -11,12 +11,12 @@ Replace module objects such as `maps` and tupled arguments with the module
 function and curried arguments:
 
 ```fsharp
-// v4
+// Earlier release candidates
 let map: BeamMap<string, int> = maps.new_ ()
 let map = maps.put ("name", 42, map)
 let name = maps.get ("name", map)
 
-// v5
+// Current curried API
 module BeamMaps = Fable.Beam.Maps
 
 let map: BeamMap<string, int> = BeamMaps.empty ()
@@ -36,9 +36,10 @@ let updated =
 ## Use semantic names
 
 Where an OTP function used arity or an atom/boolean mode to select an operation,
-v5 gives each operation a descriptive name. Common String changes are:
+the curried API gives each operation a descriptive name. Common String changes
+are:
 
-| v4 | v5 |
+| Earlier release candidates | Current curried API |
 | --- | --- |
 | `str.slice (value, start, length)` | `BString.sliceLen value start length` |
 | `str.trim (value, leading)` | `BString.trimStart value` |
@@ -72,7 +73,7 @@ would shadow FSharp.Core: `BeamMaps`, `BeamLists`, `BeamMath`, and `BString`.
 
 ## Pair JSX with Beam
 
-`Fable.Beam.Jsx` has an explicit dependency on `Fable.Beam`. During the v5
-release candidates, pair `Fable.Beam 5.0.0-rc.37` with
+`Fable.Beam.Jsx` has an explicit dependency on `Fable.Beam`. During the 5.0
+release-candidate series, pair `Fable.Beam 5.0.0-rc.37` with
 `Fable.Beam.Jsx 5.0.0-rc.9`. The package accepts `Fable.Beam >=
 5.0.0-rc.37` and `< 6.0.0`, and NuGet restores a compatible core package.

--- a/MIGRATING-TO-V5.md
+++ b/MIGRATING-TO-V5.md
@@ -1,0 +1,78 @@
+# Migrating to v5
+
+v5 makes the public binding API consistently curried. Functions take their
+configuration or input first and the value being transformed last, which makes
+ordinary F# pipelines work naturally. The old public `ImportAll` objects and
+their tupled calls are gone.
+
+## Update calls
+
+Replace module objects such as `maps` and tupled arguments with the module
+function and curried arguments:
+
+```fsharp
+// v4
+let map: BeamMap<string, int> = maps.new_ ()
+let map = maps.put ("name", 42, map)
+let name = maps.get ("name", map)
+
+// v5
+module BeamMaps = Fable.Beam.Maps
+
+let map: BeamMap<string, int> = BeamMaps.empty ()
+let map = BeamMaps.put "name" 42 map
+let name = BeamMaps.get "name" map
+```
+
+The collection is last, so common transformations can be piped:
+
+```fsharp
+let updated =
+    BeamMaps.empty ()
+    |> BeamMaps.put "name" (box "Ada")
+    |> BeamMaps.put "active" (box true)
+```
+
+## Use semantic names
+
+Where an OTP function used arity or an atom/boolean mode to select an operation,
+v5 gives each operation a descriptive name. Common String changes are:
+
+| v4 | v5 |
+| --- | --- |
+| `str.slice (value, start, length)` | `BString.sliceLen value start length` |
+| `str.trim (value, leading)` | `BString.trimStart value` |
+| `str.trim (value, trailing)` | `BString.trimEnd value` |
+| `str.equal (left, right, true)` | `BString.equalCaseInsensitive left right` |
+| `str.pad (value, length, leading)` | `BString.padStart value length` |
+| `str.pad (value, length, trailing)` | `BString.padEnd value length` |
+
+```fsharp
+module BString = Fable.Beam.String
+
+let label = "  Ada  " |> BString.trimStart
+let short = BString.sliceLen "Fable.Beam" 0 5
+```
+
+## Choose friendly or native values deliberately
+
+The normal functions return familiar F# values. A `*Raw` function is available
+where retaining Erlang's native list or chardata shape is useful to a BEAM
+consumer. Use it only when that representation is required:
+
+```fsharp
+let text = BString.padEnd "Ada" 8
+let chardata = BString.padEndRaw "Ada" 8
+```
+
+## Avoid FSharp.Core collisions
+
+Keep the source-faithful module names, and alias them at the use site when they
+would shadow FSharp.Core: `BeamMaps`, `BeamLists`, `BeamMath`, and `BString`.
+
+## Pair JSX with Beam
+
+`Fable.Beam.Jsx` has an explicit dependency on `Fable.Beam`. During the v5
+release candidates, pair `Fable.Beam 5.0.0-rc.37` with
+`Fable.Beam.Jsx 5.0.0-rc.9`. The package accepts `Fable.Beam >=
+5.0.0-rc.37` and `< 6.0.0`, and NuGet restores a compatible core package.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Libraries built on top of Fable.Beam:
 | `Fable.Beam.Cowboy` | Cowboy HTTP server bindings |
 | `Fable.Beam.Jsx` | jsx JSON library bindings |
 
+`Fable.Beam.Jsx` depends on `Fable.Beam`. During the v5 release candidates,
+install the paired versions: `Fable.Beam 5.0.0-rc.37` and
+`Fable.Beam.Jsx 5.0.0-rc.9`. The JSX package requires `Fable.Beam >=
+5.0.0-rc.37` and `< 6.0.0`, so NuGet reports an incompatible selection at
+restore time.
+
 ### Fable.Beam — OTP Modules
 
 | Module | Binding | Description |
@@ -89,17 +95,18 @@ paket add Fable.Beam.Jsx      # optional: JSON
 Then use the bindings in your F# code:
 
 ```fsharp
-open Fable.Core
 open Fable.Core.BeamInterop
+
 open Fable.Beam.Erlang
-open Fable.Beam.Timer
-open Fable.Beam.Maps
+
+module BeamMaps = Fable.Beam.Maps
+module BeamTimer = Fable.Beam.Timer
 
 // Process management
 let pid = self ()
 let ref = makeRef ()
 let child = spawn (fun () ->
-    Timer.sleep 1000
+    BeamTimer.sleep 1000
 )
 
 // Send and receive messages
@@ -116,13 +123,13 @@ match Erlang.receive<Msg> 5000 with
 | None -> printfn "Timeout"
 
 // Typed Erlang maps (generic — no box needed)
-let m: BeamMap<string, int> = maps.new_ ()
-let m = maps.put ("key", 42, m)
-let v = maps.get ("key", m)  // returns int
+let map: BeamMap<string, int> = BeamMaps.empty ()
+let map = BeamMaps.put "key" 42 map
+let value = BeamMaps.get "key" map  // returns int
 
 // Timers
-Timer.sleep 100
-let ms = Timer.seconds 30  // 30000
+BeamTimer.sleep 100
+let ms = BeamTimer.seconds 30  // 30000
 
 // Process monitoring
 let monRef = monitor child
@@ -132,6 +139,13 @@ demonitorFlush monRef
 put (box "my_key") (box 42) |> ignore
 let value = get (box "my_key")
 ```
+
+For modules that collide with FSharp.Core names, use a short explicit alias in
+examples and application code: `BeamMaps`, `BeamLists`, `BeamMath`, and
+`BString` for `Fable.Beam.String`. All public binding functions are curried;
+the evolving collection or value is the final argument, so they compose with
+pipelines. See [the v5 migration guide](MIGRATING-TO-V5.md) for renamed and
+raw-value APIs.
 
 ### JSON with jsx
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Libraries built on top of Fable.Beam:
 | `Fable.Beam.Cowboy` | Cowboy HTTP server bindings |
 | `Fable.Beam.Jsx` | jsx JSON library bindings |
 
-`Fable.Beam.Jsx` depends on `Fable.Beam`. During the v5 release candidates,
-install the paired versions: `Fable.Beam 5.0.0-rc.37` and
+`Fable.Beam.Jsx` depends on `Fable.Beam`. During the 5.0 release-candidate
+series, install the paired versions: `Fable.Beam 5.0.0-rc.37` and
 `Fable.Beam.Jsx 5.0.0-rc.9`. The JSX package requires `Fable.Beam >=
 5.0.0-rc.37` and `< 6.0.0`, so NuGet reports an incompatible selection at
 restore time.
@@ -144,8 +144,8 @@ For modules that collide with FSharp.Core names, use a short explicit alias in
 examples and application code: `BeamMaps`, `BeamLists`, `BeamMath`, and
 `BString` for `Fable.Beam.String`. All public binding functions are curried;
 the evolving collection or value is the final argument, so they compose with
-pipelines. See [the v5 migration guide](MIGRATING-TO-V5.md) for renamed and
-raw-value APIs.
+pipelines. See [the curried API migration guide](MIGRATING-TO-CURRIED-API.md)
+for renamed and raw-value APIs.
 
 ### JSON with jsx
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,6 +4,7 @@ source https://api.nuget.org/v3/index.json
 storage: none
 framework: netstandard2.0
 
+nuget Fable.Beam >= 5.0.0-rc.37 < 6.0 rc
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core >= 5.0.0 lowest_matching: true
 

--- a/paket.lock
+++ b/paket.lock
@@ -2,6 +2,9 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
+    Fable.Beam (5.0.0-rc.37)
+      Fable.Core (>= 5.0)
+      FSharp.Core (>= 5.0)
     Fable.Core (5.0)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)

--- a/src/jsx/Fable.Beam.Jsx.fsproj
+++ b/src/jsx/Fable.Beam.Jsx.fsproj
@@ -14,6 +14,9 @@
     <PackageProjectUrl>https://github.com/fable-compiler/Fable.Beam</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Fable.Beam.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Jsx.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/jsx/paket.references
+++ b/src/jsx/paket.references
@@ -1,2 +1,3 @@
 FSharp.Core
 Fable.Core
+Fable.Beam


### PR DESCRIPTION
## Summary
- add a concise release-candidate migration guide for curried bindings, semantic names, raw values, and aliases
- update README examples to the curried Maps API and document the JSX/Beam pairing
- declare the Fable.Beam dependency range for Fable.Beam.Jsx through Paket

## Validation
- just test: 412 passed
- packed Fable.Beam.Jsx and verified its nuspec declares Fable.Beam [5.0.0-rc.37, 6.0.0-rc)