### PR TITLE
chore: release 5.0.0

### DIFF
--- a/src/cowboy/CHANGELOG.md
+++ b/src/cowboy/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam.Cowboy
+force_version: 5.0.0
 ---
 
 # Changelog

--- a/src/cowboy/CHANGELOG.md
+++ b/src/cowboy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: 0b4f4912c8ff47f3a7d3561c59146626092d4e4f
+last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam.Cowboy
 ---
 

--- a/src/jsx/CHANGELOG.md
+++ b/src/jsx/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: 0b4f4912c8ff47f3a7d3561c59146626092d4e4f
+last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam.Jsx
 ---
 

--- a/src/jsx/CHANGELOG.md
+++ b/src/jsx/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam.Jsx
+force_version: 5.0.0
 ---
 
 # Changelog

--- a/src/otp/CHANGELOG.md
+++ b/src/otp/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: 0b4f4912c8ff47f3a7d3561c59146626092d4e4f
+last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam
 ---
 

--- a/src/otp/CHANGELOG.md
+++ b/src/otp/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 last_commit_released: 0b4f491a726d8a92ed3449f00f4ad7c6234a770b
 name: Fable.Beam
+force_version: 5.0.0
 ---
 
 # Changelog


### PR DESCRIPTION
Promotes the 5.0.0 release through the PR workflow by correcting the changelog release markers used by ShipIt.\n\nThe change is limited to the OTP, Cowboy, and JSX changelogs.